### PR TITLE
Shop stock editing and bugfixes

### DIFF
--- a/Libraries/Farmhand/Events/Arguments/UtilityEvents/EventArgsOnGetDwarfShopStock.cs
+++ b/Libraries/Farmhand/Events/Arguments/UtilityEvents/EventArgsOnGetDwarfShopStock.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Farmhand.Events.Arguments
+{
+    public class EventArgsOnGetDwarfShopStock : EventArgs
+    {
+    }
+}

--- a/Libraries/Farmhand/Events/UtilityEvents.cs
+++ b/Libraries/Farmhand/Events/UtilityEvents.cs
@@ -1,0 +1,20 @@
+﻿using Farmhand.Attributes;
+using Farmhand.Events.Arguments;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Farmhand.Events
+{
+    public class UtilityEvents
+    {
+        public static event EventHandler<EventArgsOnGetDwarfShopStock> OnPostGetDwarfShopStock = delegate { };
+
+        [Hook(HookType.Exit, "StardewValley.Utility", "getDwarfShopStock")]
+        internal static void InvokePostGetDwarfShopStock()
+        {
+            EventCommon.SafeInvoke(OnPostGetDwarfShopStock, null, new EventArgsOnGetDwarfShopStock());
+        }
+    }
+}

--- a/Libraries/Farmhand/Farmhand.csproj
+++ b/Libraries/Farmhand/Farmhand.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Events\Arguments\PlayerEvents\EventArgsOnLevelUp.cs" />
     <Compile Include="Events\Arguments\SaveEvents\EventArgsOnAfterLoad.cs" />
     <Compile Include="Events\Arguments\SaveEvents\EventArgsOnBeforeLoad.cs" />
+    <Compile Include="Events\Arguments\UtilityEvents\EventArgsOnGetDwarfShopStock.cs" />
     <Compile Include="Events\ControlEvents.cs" />
     <Compile Include="Events\EventCommon.cs" />
     <Compile Include="Events\EventManager.cs" />
@@ -151,6 +152,7 @@
     <Compile Include="Events\SerializerEvents.cs" />
     <Compile Include="Events\TimeEvents.cs" />
     <Compile Include="Events\UiEvents.cs" />
+    <Compile Include="Events\UtilityEvents.cs" />
     <Compile Include="Helpers\ExtensionMethods.cs" />
     <Compile Include="Helpers\CompatibilityLayer.cs" />
     <Compile Include="Helpers\MainRedirect.cs" />

--- a/Mods/TestToolMod/TestToolMod.cs
+++ b/Mods/TestToolMod/TestToolMod.cs
@@ -35,8 +35,21 @@ namespace TestToolMod
 
         private void PlayerEvents_OnFarmerChanged(object sender, System.EventArgs e)
         {
+            // Check if the player already has this tool
+            bool hasTool = false;
+            for(int i=0; i<Game1.player.items.Count; i++)
+            {
+                if(Game1.player.items[i] is TestTool)
+                {
+                    hasTool = true;
+                }
+            }
+
             // Give the player the tool
-            Farmhand.API.Player.Player.AddTool<TestTool>();
+            if(!hasTool)
+            {
+                Farmhand.API.Player.Player.AddTool<TestTool>();
+            }
         }
     }
 }

--- a/Mods/TestToolMod/Tools/TestTool.cs
+++ b/Mods/TestToolMod/Tools/TestTool.cs
@@ -30,6 +30,11 @@ namespace TestToolMod.Tools
             this.upgradeLevel = Information.UpgradeLevel;
         }
 
+        // Overriding this to return without any chances keeps base from altering our sprite sheet index
+        public override void setNewTileIndexForUpgradeLevel()
+        {
+            return;
+        }
 
         public override void beginUsing(GameLocation location, int x, int y, Farmer who)
         {


### PR DESCRIPTION
- Added an example of editing shop stock in the TestCropMod example mod

Edited both pierre's and the hospital's shop stock to include new items.
Editing the shop stock is fairly simple through events, so making some
kind of API tool to do it isn't required, although it would be nice,
especially to have shop stock order sorting. I'm not sure where a tool
to register that kind of stuff would go, but I'll be thinking about it.

- Added OnGetDwarfShopStock event

This won't be very useful until returnable events are working, and I
didn't want to add all shop events until they are. For now the example
doesn't even use this.

- Fixed bug in TestToolMod where the sprite sheet index is lost upon
reloading

There's a virtual method in StardewValley.Tool that is called which
messes up the sprite sheet index based on the tool upgrade level.
Overriding this and just returning immediately solves the problem.