### PR TITLE
A really tiny bugfix

### DIFF
--- a/Installers/FarmhandInstaller-UI/MainWindow.xaml.cs
+++ b/Installers/FarmhandInstaller-UI/MainWindow.xaml.cs
@@ -57,6 +57,7 @@ namespace WpfTest
 
         private void buttonInstall_Click(object sender, RoutedEventArgs e)
         {
+            StardewFile = textBoxExecPath.Text;
             SwitchToInstallationUI();
             Packer = new BackgroundWorker();
             Packer.DoWork += Packer_DoWork;


### PR DESCRIPTION
Install UI Text box bug fix:
- Fixed a potential bug where a file address manually typed into the UI
installers file selector text box would not be updated and used, as the
variable StardewFile was only updated upon confirming a file selection
with the file selection window dialog.