### PR TITLE
ContentManager Hook Override

### DIFF
--- a/Installers/Patcher/FarmhandPatcherCommon/Cecil/CecilContext.cs
+++ b/Installers/Patcher/FarmhandPatcherCommon/Cecil/CecilContext.cs
@@ -105,6 +105,26 @@ namespace Farmhand.Cecil
             return methodDef;
         }
 
+        public MethodDefinition GetMethodDefinitionFullName(string type, string method, Func<MethodDefinition, bool> selector = null)
+        {
+            MethodDefinition methodDef = null;
+            TypeDefinition typeDef = GetTypeDefinition(type);
+
+            if (typeDef != null)
+            {
+                if (selector == null)
+                {
+                    methodDef = typeDef.Methods.FirstOrDefault(m => m.FullName == method);
+                }
+                else
+                {
+                    methodDef = typeDef.Methods.Where(m => m.FullName == method).FirstOrDefault(selector);
+                }
+            }
+
+            return methodDef;
+        }
+
         public MethodReference GetConstructorReference(TypeDefinition typeDefinition, Func<MethodDefinition, bool> selector = null)
         {
             if (selector == null)

--- a/Installers/Patcher/FarmhandPatcherFirstPass/PatcherFirstPass.cs
+++ b/Installers/Patcher/FarmhandPatcherFirstPass/PatcherFirstPass.cs
@@ -98,11 +98,11 @@ namespace Farmhand
             {
                 if (attribute.GenericArguments != null && attribute.GenericArguments.Any())
                 {
-                    CecilHelper.RedirectConstructorFromBase(cecilContext, asmType, attribute.GenericArguments, attribute.Type, attribute.Method);
+                    CecilHelper.RedirectConstructorFromBase(cecilContext, asmType, attribute.GenericArguments, attribute.Type, attribute.Method, attribute.Parameters);
                 }
                 else
                 {
-                    CecilHelper.RedirectConstructorFromBase(cecilContext, asmType, attribute.Type, attribute.Method);
+                    CecilHelper.RedirectConstructorFromBase(cecilContext, asmType, attribute.Type, attribute.Method, attribute.Parameters);
                 }
             }
         }

--- a/Installers/Patcher/FarmhandPatcherSecondPass/PatcherSecondPass.cs
+++ b/Installers/Patcher/FarmhandPatcherSecondPass/PatcherSecondPass.cs
@@ -105,11 +105,11 @@ namespace Farmhand
             {
                 if (attribute.GenericArguments != null && attribute.GenericArguments.Any())
                 {
-                    CecilHelper.RedirectConstructorFromBase(cecilContext, asmType, attribute.GenericArguments, attribute.Type, attribute.Method);
+                    CecilHelper.RedirectConstructorFromBase(cecilContext, asmType, attribute.GenericArguments, attribute.Type, attribute.Method, attribute.Parameters);
                 }
                 else
                 {
-                    CecilHelper.RedirectConstructorFromBase(cecilContext, asmType, attribute.Type, attribute.Method);
+                    CecilHelper.RedirectConstructorFromBase(cecilContext, asmType, attribute.Type, attribute.Method, attribute.Parameters);
                 }
             }
         }

--- a/Libraries/Farmhand/Attributes/HookRedirectConstructorFromBaseAttribute.cs
+++ b/Libraries/Farmhand/Attributes/HookRedirectConstructorFromBaseAttribute.cs
@@ -5,15 +5,24 @@ namespace Farmhand.Attributes
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class HookRedirectConstructorFromBaseAttribute : Attribute
     {
-        public HookRedirectConstructorFromBaseAttribute(string type, string method, params Type[] genericArguments)
+        public HookRedirectConstructorFromBaseAttribute(string type, string method, Type[] parameters, params Type[] genericArguments)
         {
             Type = type;
             Method = method;
+            Parameters = parameters;
             GenericArguments = genericArguments;
         }
-        
+
+        public HookRedirectConstructorFromBaseAttribute(string type, string method, params Type[] GenericArguments)
+        {
+            Type = type;
+            Method = method;
+            Parameters = new Type[] { };
+        }
+
         public string Type { get; set; }
         public string Method { get; set; }
+        public Type[] Parameters { get; set; }
         public Type[] GenericArguments { get; set; }
     }
     

--- a/Libraries/Farmhand/Attributes/HookRedirectConstructorFromBaseAttribute.cs
+++ b/Libraries/Farmhand/Attributes/HookRedirectConstructorFromBaseAttribute.cs
@@ -13,7 +13,7 @@ namespace Farmhand.Attributes
             GenericArguments = genericArguments;
         }
 
-        public HookRedirectConstructorFromBaseAttribute(string type, string method, params Type[] GenericArguments)
+        public HookRedirectConstructorFromBaseAttribute(string type, string method)
         {
             Type = type;
             Method = method;

--- a/Libraries/Farmhand/Content/ContentManager.cs
+++ b/Libraries/Farmhand/Content/ContentManager.cs
@@ -10,6 +10,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
 using Farmhand.Registries.Containers;
+using System.Globalization;
 
 namespace Farmhand.Content
 {
@@ -17,6 +18,10 @@ namespace Farmhand.Content
     /// An override for the XNA ContentManager which deals with loading custom XNBs when mods have registered custom overrides. Can also be used by mods
     /// to load their own XNB data
     /// </summary>
+    [HookRedirectConstructorFromBase("StardewValley.Game1", ".ctor", new Type[]{ typeof(IServiceProvider), typeof(System.String) })]
+    [HookRedirectConstructorFromBase("StardewValley.Game1", "dummyLoad", new Type[] { typeof(IServiceProvider), typeof(System.String) })]
+    [HookRedirectConstructorFromBase("StardewValley.Game1", "LoadContent", new Type[] { typeof(IServiceProvider), typeof(System.String) })]
+    [HookRedirectConstructorFromBase("StardewValley.LocalizedContentManager", "CreateTemporary", new Type[] { typeof(IServiceProvider), typeof(System.String), typeof(CultureInfo), typeof(string) } )]
     public class ContentManager : StardewValley.LocalizedContentManager
     {
         // A tracker, so we can check if the current Game1.temporaryContent is our override, to prevent uneccesary overriding

--- a/Libraries/Farmhand/Content/ContentManager.cs
+++ b/Libraries/Farmhand/Content/ContentManager.cs
@@ -24,9 +24,6 @@ namespace Farmhand.Content
     [HookRedirectConstructorFromBase("StardewValley.LocalizedContentManager", "CreateTemporary", new Type[] { typeof(IServiceProvider), typeof(System.String), typeof(CultureInfo), typeof(string) } )]
     public class ContentManager : StardewValley.LocalizedContentManager
     {
-        // A tracker, so we can check if the current Game1.temporaryContent is our override, to prevent uneccesary overriding
-        protected static Microsoft.Xna.Framework.Content.ContentManager _tempManagerTracker = null;
-
         public static List<IContentInjector> ContentInjectors = new List<IContentInjector>()
         {
             new ModXnbInjector(),
@@ -36,26 +33,6 @@ namespace Farmhand.Content
             new CropInjector(),
             new WeaponInjector()
         };
-
-        //TODO Do not redirect this way. There are so many (pointless) separate instances of ContentManager, and we'll need to override them all as soon as they're 
-        //created. It's something more suited to the ConstructionRedirect hook.
-        [Hook(HookType.Entry, "StardewValley.Game1", "LoadContent")]
-        internal static void ConstructionHook()
-        {
-            Log.Verbose("Using Farmhand's ContentManager");
-            Game1.game1.Content = new ContentManager(Game1.game1.Content.ServiceProvider, Game1.game1.Content.RootDirectory);
-        }
-
-        [Hook(HookType.Entry, "StardewValley.Object", "performObjectDropInAction")]
-        internal static void ConstructionHookObject()
-        {
-            if (Game1.temporaryContent != _tempManagerTracker)
-            {
-                Log.Verbose("Using Farmhand's ContentManager on Temporary Content Manager");
-                Game1.temporaryContent = new ContentManager(Game1.game1.Content.ServiceProvider, Game1.game1.Content.RootDirectory);
-                _tempManagerTracker = Game1.temporaryContent;
-            }
-        }
 
         public ContentManager(IServiceProvider serviceProvider, string rootDirectory, System.Globalization.CultureInfo currentCulture, string languageCodeOverride)
             : base(serviceProvider, rootDirectory, currentCulture, languageCodeOverride)


### PR DESCRIPTION
- Added HookRedirectConstructorFromBase options to allow hooking of
constructors with specific arguments. This was neccessary because if
left unspecified, only the first listed constructor in the base class
could be hooked. In order to do this, I added a new field to the
HookRedirectConstructorFromBaseAttribute class, "Parameters", which is
then used by the patchers to specify exactly which constructor needs to
be hooked in any given method. The changes to CecilHelper and
CecilContext mainly involed moving over to a FullName check for the
constructor, rather than just checking Name. An additional method was
added to CecilContext to allow for this kind of checking, called
"GetMethodDefinitionFullName", which functions exactly like
"GetMethodDefinition", except it checks by FullName. Since MethodInfo
doesn't provide a FullName property, a custom FullName string had to be
built in CecilHelper's RedirectConstructorFromBase method. This was done
for the non-generic utilizing overload, this functionality will have to
be added for constructors involving generics later.

- Used new constructor hooking features to properly hook all
instantiations of StardewValley.LocalizedContentManager to instead
initialize Farmhand.Content.ContentManager. This effectively solves the
issue of all the scattered temporary content managers, since now
everything goes through Farmhand's overriding ContentManager.