### PR TITLE
MineShaft Spawn Chance Registry and Fixes to Returnable Hooks

### DIFF
--- a/Installers/Patcher/FarmhandPatcherCommon/Helpers/CecilHelper.cs
+++ b/Installers/Patcher/FarmhandPatcherCommon/Helpers/CecilHelper.cs
@@ -149,9 +149,9 @@ namespace Farmhand.Helpers
                 var loadOld = ilProcessor.Create(OpCodes.Ldloc, oldContainerVariable);
                 var loadNew = ilProcessor.Create(OpCodes.Ldloc, containerVariable);
                 instructions.Add(ilProcessor.Create(OpCodes.Brfalse, loadOld));
-                instructions.Add(loadOld);
-                instructions.Add(brToRet);
                 instructions.Add(loadNew);
+                instructions.Add(brToRet);
+                instructions.Add(loadOld);
             }
 
             foreach (var inst in instructions)

--- a/Installers/Patcher/FarmhandPatcherFirstPass/PatcherFirstPass.cs
+++ b/Installers/Patcher/FarmhandPatcherFirstPass/PatcherFirstPass.cs
@@ -22,6 +22,7 @@ namespace Farmhand
             FarmhandAssemblies.Add(Assembly.LoadFrom(PatcherConstants.FarmhandDll));
             
             HookApiEvents(cecilContext);
+            HookOutputableApiEvents(cecilContext);
             HookApiFieldProtectionAlterations<HookAlterBaseFieldProtectionAttribute>(cecilContext);
             HookApiTypeProtectionAlterations<HookAlterProtectionAttribute>(cecilContext);
             HookApiVirtualAlterations<HookForceVirtualBaseAttribute>(cecilContext);
@@ -76,6 +77,56 @@ namespace Farmhand
                                         (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
                                 case HookType.Exit: CecilHelper.InjectExitMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute>
                                         (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+        }
+
+        private void HookOutputableApiEvents(CecilContext cecilContext)
+        {
+            try
+            {
+                var methods = FarmhandAssemblies.SelectMany(a => a.GetTypes())
+                            .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+                            .Where(m => m.GetCustomAttributes(typeof(HookReturnableAttribute), false).Any())
+                            .ToArray();
+
+                foreach (var method in methods)
+                {
+                    if (method.DeclaringType == null) continue;
+
+                    var typeName = method.DeclaringType.FullName;
+                    var methodName = method.Name;
+                    var hookAttributes = method.GetCustomAttributes(typeof(HookReturnableAttribute), false).Cast<HookReturnableAttribute>();
+
+                    foreach (var hook in hookAttributes)
+                    {
+                        var hookTypeName = hook.Type;
+                        var hookMethodName = hook.Method;
+                        try
+                        {
+                            switch (hook.HookType)
+                            {
+                                case HookType.Entry:
+                                    CecilHelper.InjectReturnableEntryMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute,
+                                        UseOutputBindAttribute>
+                                        (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
+                                case HookType.Exit:
+                                    CecilHelper.InjectReturnableExitMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute,
+                                        UseOutputBindAttribute>
+                        (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
+                                default:
+                                    throw new Exception("Unknown HookType");
                             }
                         }
                         catch (Exception ex)

--- a/Libraries/Farmhand/API/Locations/MineShaft.cs
+++ b/Libraries/Farmhand/API/Locations/MineShaft.cs
@@ -1,0 +1,111 @@
+﻿using Farmhand.API.Monsters;
+using Farmhand.Attributes;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Farmhand.API.Locations
+{
+    /// <summary>
+    /// Provides functions relating to the MineShaft location
+    /// </summary>
+    public class MineShaft
+    {
+        public static List<MineshaftMonsterSpawnChance> MonsterSpawnChances = new List<MineshaftMonsterSpawnChance>();
+
+        private static readonly Random Random = new Random();
+
+        /// <summary>
+        /// Adds the chance for a given monster to spawn
+        /// </summary>
+        /// <param name="monsterType">Type of monster that will spawn</param>
+        /// <param name="monsterInformation">Information of monster that will spawn</param>
+        /// <param name="spawnWeight">Chance that this monster will spawn, the higher the number, the higher the chance, with 1 being the weight of the default monster</param>
+        /// <param name="minLevel">earliest mineshaft level that this spawn chance applies</param>
+        /// <param name="maxLevel">latest minehsaft level that this spawn chance applies</param>
+        public static void AddMonsterSpawnChance(Type monsterType, MonsterInformation monsterInformation, double spawnWeight, int minLevel, int maxLevel)
+        {
+            // Create the new spawn chance data object
+            MineshaftMonsterSpawnChance newSpawnChance = new MineshaftMonsterSpawnChance(monsterType, monsterInformation, spawnWeight, minLevel, maxLevel);
+
+            // Add it to the MonsterSpawnChances list
+            MonsterSpawnChances.Add(newSpawnChance);
+        }
+
+        [HookReturnable(HookType.Exit, "StardewValley.Locations.MineShaft", "getMonsterForThisLevel")]
+        internal static StardewValley.Monsters.Monster GetMonsterForThisLevel(
+            [UseOutputBind] ref bool useOutput,
+            [InputBind(typeof(int), "level")] int level,
+            [InputBind(typeof(int), "xTile")] int xTile,
+            [InputBind(typeof(int), "yTile")] int yTile)
+        {
+            // Create the spawning location vector the same way it's handled in the hooked method
+            Vector2 vector = new Vector2((float)xTile, (float)yTile) * (float)StardewValley.Game1.tileSize;
+
+            // Create a new sub-list of spawn chances that apply to this level
+            var ApplicableChances = MonsterSpawnChances.Where(c => c.MinLevel <= level && c.MaxLevel >= level);
+            // Get the sum of all chance weights that apply. Starts at 1 for the default value's weight
+            double weightSum = 1.0;
+            foreach (MineshaftMonsterSpawnChance chance in ApplicableChances)
+            {
+                weightSum += chance.SpawnWeight;
+            }
+
+            // Get a random double between 0 and 1
+            double randomValue = Random.NextDouble();
+            // Current Evaluated Weight for the following loop
+            double currentWeight = 0.0;
+            // Loop through the applicable chances, and determine if luck has shined upon the monster it contains
+            foreach (MineshaftMonsterSpawnChance chance in ApplicableChances)
+            {
+                if( currentWeight < (randomValue*weightSum) && (currentWeight + chance.SpawnWeight) >= (randomValue*weightSum) )
+                {
+                    // Create the monster object and pass it back to be used
+                    StardewValley.Monsters.Monster newMonsterObject = (StardewValley.Monsters.Monster)Activator.CreateInstance(chance.MonsterType, chance.Information, vector);
+
+                    useOutput = true;
+                    return newMonsterObject;
+                }
+
+                currentWeight += chance.SpawnWeight;
+            }
+
+            // Luck did not shine on any custom spawn chances, use the default
+            useOutput = false;
+            return null;
+        }
+
+        /// <summary>
+        /// A data class which holds monster spawn chance information for the mineshaft
+        /// </summary>
+        public class MineshaftMonsterSpawnChance
+        {
+            // Monster type
+            public Type MonsterType { get; set; }
+
+            // Monster name
+            public MonsterInformation Information { get; set; }
+
+            // Spawn weight
+            public double SpawnWeight { get; set; }
+
+            // Minimum mineshaft level
+            public int MinLevel { get; set; }
+
+            // Maximum mineshaft level
+            public int MaxLevel { get; set; }
+
+            public MineshaftMonsterSpawnChance(Type monsterType, MonsterInformation information, double spawnWeight, int minLevel, int maxLevel)
+            {
+                MonsterType = monsterType;
+                Information = information;
+                SpawnWeight = spawnWeight;
+                MinLevel = minLevel;
+                MaxLevel = maxLevel;
+            }
+        }
+    }
+}

--- a/Libraries/Farmhand/Events/MineShaftEvents.cs
+++ b/Libraries/Farmhand/Events/MineShaftEvents.cs
@@ -9,16 +9,6 @@ namespace Farmhand.Events
 {
     public class MineShaftEvents
     {
-        public static event EventHandler<EventArgsGetMonsterForThisLevel> OnGetMonsterForThisLevel = delegate { };
-
-        [Hook(HookType.Exit, "StardewValley.Locations.MineShaft", "getMonsterForThisLevel")]
-        internal static void GetMonsterForThisLevel([ThisBind] object @this,
-            [InputBind(typeof(int), "level")] int level,
-            [InputBind(typeof(int), "xTile")] int xTile,
-            [InputBind(typeof(int), "yTile")] int yTile
-        )
-        {
-            EventCommon.SafeInvoke(OnGetMonsterForThisLevel, @this, new EventArgsGetMonsterForThisLevel(level, xTile, yTile));
-        }
+        
     }
 }

--- a/Libraries/Farmhand/Farmhand.csproj
+++ b/Libraries/Farmhand/Farmhand.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\..\WorkingDirectory\Microsoft.Xna.Framework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553">
-        <HintPath>C:\Windows\Microsoft.NET\assembly\GAC_32\Microsoft.Xna.Framework.Graphics\v4.0_4.0.0.0__842cf8be1de50553\Microsoft.Xna.Framework.Game.dll</HintPath>
-        <HintPath>..\..\WorkingDirectory\Microsoft.Xna.Framework.Game.dll</HintPath>
+      <HintPath>C:\Windows\Microsoft.NET\assembly\GAC_32\Microsoft.Xna.Framework.Graphics\v4.0_4.0.0.0__842cf8be1de50553\Microsoft.Xna.Framework.Game.dll</HintPath>
+      <HintPath>..\..\WorkingDirectory\Microsoft.Xna.Framework.Game.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
@@ -88,6 +88,7 @@
     <Compile Include="API\Items\ItemCategory.cs" />
     <Compile Include="API\Items\ItemInformation.cs" />
     <Compile Include="API\Items\ItemType.cs" />
+    <Compile Include="API\Locations\MineShaft.cs" />
     <Compile Include="API\Monsters\Monster.cs" />
     <Compile Include="API\Monsters\MonsterInformation.cs" />
     <Compile Include="API\Pulse\Pulse.cs" />
@@ -215,7 +216,6 @@
     <Compile Include="Test.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="API\Locations\" />
     <Folder Include="API\Machines\" />
   </ItemGroup>
   <ItemGroup>

--- a/Mods/TestMonsterMod/TestMonsterMod.cs
+++ b/Mods/TestMonsterMod/TestMonsterMod.cs
@@ -1,13 +1,6 @@
 ﻿using Farmhand;
 using Farmhand.API.Generic;
 using Farmhand.API.Monsters;
-using Farmhand.Events;
-using Farmhand.Events.Arguments.GlobalRoute;
-using Farmhand.Overrides;
-using Farmhand.Registries;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using StardewValley.Monsters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,9 +17,6 @@ namespace TestMonsterMod
         public override void Entry()
         {
             Farmhand.Events.GameEvents.OnAfterLoadedContent += GameEvents_OnAfterLoadedContent;
-            
-            // TODO once returnable events are working, this can be replaced with a proper event
-            Farmhand.Events.GlobalRouteManager.Listen(ListenerType.Pre, "StardewValley.Locations.MineShaft", "getMonsterForThisLevel", MineshaftEvents_OnGetMonsterForThisLevel);
         }
 
         private void GameEvents_OnAfterLoadedContent(object sender, System.EventArgs e)
@@ -54,18 +44,8 @@ namespace TestMonsterMod
                 MineMonster = true,
                 ExperienceGained = 5
             });
-        }
 
-        private void MineshaftEvents_OnGetMonsterForThisLevel(EventArgsGlobalRoute e)
-        {
-            // Essentially, this is giving a 30% chance to spawn TestMonster instead of another monster
-            if (Game1.random.NextDouble() < .3)
-            {
-                var args = e as EventArgsGlobalRouteReturnable;
-
-                args.Output = new TestMonster(Farmhand.API.Monsters.Monster.Monsters["TestMonster"],
-                    new Vector2((int)e.Parameters[2], (int)e.Parameters[3]) * (float)Game1.tileSize);
-            }
+            Farmhand.API.Locations.MineShaft.AddMonsterSpawnChance(typeof(TestMonster), Farmhand.API.Monsters.Monster.Monsters["TestMonster"], 1.0, 1, 200);
         }
     }
 }


### PR DESCRIPTION
- Fixed Returnable Hooks not being installed in the first pass installer
- Fixed Returnable Hooks not utilizing the returned value on exit
- Added a new API\Locations\MineShaft class to handle things to do
involving the MineShaft Location
- Added a way to register chances for monsters to spawn in the
API\Locations\MineShaft class
- Removed GetMonsterForThisLevel event from MineShaftEvents