### PR TITLE
Hook Redirect Constructor To Method and Big Craftables changes

### DIFF
--- a/Installers/Patcher/FarmhandPatcherCommon/Patcher.cs
+++ b/Installers/Patcher/FarmhandPatcherCommon/Patcher.cs
@@ -173,6 +173,8 @@ namespace Farmhand
 
         protected abstract void HookApiEvents(CecilContext cecilContext);
 
+        protected abstract void HookConstructionToMethodRedirectors(CecilContext cecilContext);
+
         protected void InjectFarmhandCoreClasses(string output, params string[] inputs)
         {
             RepackOptions options = new RepackOptions();

--- a/Installers/Patcher/FarmhandPatcherSecondPass/PatcherSecondPass.cs
+++ b/Installers/Patcher/FarmhandPatcherSecondPass/PatcherSecondPass.cs
@@ -24,6 +24,7 @@ namespace Farmhand
             HookApiVirtualAlterations<HookForceVirtualBaseAttribute>(cecilContext);
             HookMakeBaseVirtualCallAlterations<HookMakeBaseVirtualCallAttribute>(cecilContext);
             HookConstructionRedirectors<HookRedirectConstructorFromBaseAttribute>(cecilContext);
+            HookConstructionToMethodRedirectors(cecilContext);
             
             HookGlobalRouting(cecilContext);
            
@@ -170,6 +171,69 @@ namespace Farmhand
                 {
                     CecilHelper.RedirectConstructorFromBase(cecilContext, asmType, attribute.Type, attribute.Method, attribute.Parameters);
                 }
+            }
+        }
+
+        protected override void HookConstructionToMethodRedirectors(CecilContext cecilContext)
+        {
+            try
+            {
+                var methods = FarmhandAssemblies.SelectMany(a => a.GetTypes())
+                            .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+                            .Where(m => m.GetCustomAttributes(typeof(HookRedirectConstructorToMethodAttribute), false).Any())
+                            .ToArray();
+
+                foreach (var method in methods)
+                {
+                    // Check if this method has any properties that would immediately disqualify it from using this hook
+                    if (method.ReturnType == typeof(void))
+                    {
+                        Logging.Log.Warning($"{method.Name} in {method.DeclaringType.FullName} cannot be used in a hook because it does not return a value!");
+                        continue;
+                    }
+                    if (!method.IsStatic)
+                    {
+                        Logging.Log.Warning($"{method.Name} in {method.DeclaringType.FullName} cannot be used in a hook because it is not static!");
+                        continue;
+                    }
+
+                    // Get the type that the method returns
+                    var typeName = method.ReturnType.FullName;
+                    // Get the name of the method
+                    var methodName = method.Name;
+                    // Get the type name of the method
+                    var methodDeclaringType = method.DeclaringType.FullName;
+                    // Get an array of parameters that the method returns
+                    var methodParameterInfo = method.GetParameters();
+                    Type[] methodParamters = new Type[methodParameterInfo.Length];
+                    for (int i = 0; i < methodParamters.Length; i++)
+                    {
+                        methodParamters[i] = methodParameterInfo[i].ParameterType;
+                    }
+
+                    // Get all the hooks for this method
+                    var hookAttributes = method.GetCustomAttributes(typeof(HookRedirectConstructorToMethodAttribute), false).Cast<HookRedirectConstructorToMethodAttribute>();
+
+                    foreach (var hook in hookAttributes)
+                    {
+                        // Get the type name that contains the method we're hooking in
+                        var hookTypeName = hook.Type;
+                        // Get the name of the method we're hooking in
+                        var hookMethodName = hook.Method;
+                        try
+                        {
+                            CecilHelper.RedirectConstructorToMethod(cecilContext, method.ReturnType, hookTypeName, hookMethodName, methodDeclaringType, methodName, methodParamters);
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
             }
         }
 

--- a/Libraries/Farmhand/API/Items/BigCraftable.cs
+++ b/Libraries/Farmhand/API/Items/BigCraftable.cs
@@ -10,11 +10,12 @@ namespace Farmhand.API.Items
     /// <summary>
     /// A class which can be extended from to create big craftable items easier, and provides functionality related to big craftables
     /// </summary>
-    public class BigCraftable : StardewValley.Object
+    public class BigCraftable
     {
         // A static list containing all registered big craftable information
         public static List<BigCraftableInformation> BigCraftables { get; } = new List<BigCraftableInformation>();
         public static Dictionary<Type, BigCraftableInformation> RegisteredTypeInformation { get; } = new Dictionary<Type, BigCraftableInformation>();
+        public static Dictionary<int, Type> RegisteredIdType { get; } = new Dictionary<int, Type>();
 
         /// <summary>
         /// Registers a new big craftable
@@ -31,25 +32,65 @@ namespace Farmhand.API.Items
 
             BigCraftables.Add(bigCraftable);
             RegisteredTypeInformation[typeof(T)] = bigCraftable;
+            RegisteredIdType[bigCraftable.Id] = typeof(T);
             TextureUtility.AddSpriteToSpritesheet(ref Game1.bigCraftableSpriteSheet, bigCraftable.Texture, bigCraftable.Id, 16, 32);
             // Reload big craftable information with the newly injected information
             StardewValley.Game1.bigCraftablesInformation = StardewValley.Game1.content.Load<Dictionary<int, string>>("Data\\BigCraftablesInformation");
         }
 
-
-        // Big Craftable Information
-        public BigCraftableInformation Information { get; set; }
-
-        public BigCraftable(BigCraftableInformation information) :
-            base(Vector2.Zero, information.Id, false)
+        [HookRedirectConstructorToMethod("StardewValley.Buildings.Barn", "performActionOnConstruction")]
+        [HookRedirectConstructorToMethod("StardewValley.Buildings.Barn", "performActionOnUpgrade")]
+        [HookRedirectConstructorToMethod("StardewValley.Buildings.Building", "dayUpdate")]
+        [HookRedirectConstructorToMethod("StardewValley.Buildings.Coop", "performActionOnConstruction")]
+        [HookRedirectConstructorToMethod("StardewValley.Buildings.Coop", "performActionOnUpgrade")]
+        [HookRedirectConstructorToMethod("StardewValley.Buildings.Coop", "upgrade")]
+        [HookRedirectConstructorToMethod("StardewValley.CraftingRecipe", "createItem")]
+        [HookRedirectConstructorToMethod("StardewValley.Debris", "updateChunks")]
+        [HookRedirectConstructorToMethod("StardewValley.Event", "checkAction")]
+        [HookRedirectConstructorToMethod("StardewValley.Event", "checkForNextCommand")]
+        [HookRedirectConstructorToMethod("StardewValley.Events.SoundInTheNightEvent", "makeChangesToLocation")]
+        [HookRedirectConstructorToMethod("StardewValley.Farm", "checkAction")]
+        [HookRedirectConstructorToMethod("StardewValley.Farmer", "tryToCraftItem")]
+        [HookRedirectConstructorToMethod("StardewValley.Game1", "loadForNewGame")]
+        [HookRedirectConstructorToMethod("StardewValley.Game1", "parseDebugInput")]
+        [HookRedirectConstructorToMethod("StardewValley.GameLocation", "answerDialogueAction")]
+        [HookRedirectConstructorToMethod("StardewValley.GameLocation", "doStarpoint")]
+        [HookRedirectConstructorToMethod("StardewValley.GameLocation", "performAction")]
+        [HookRedirectConstructorToMethod("StardewValley.LevelBuilder", "tryToAddObject")]
+        [HookRedirectConstructorToMethod("StardewValley.Locations.FarmCave", "setUpMushroomHouse")]
+        [HookRedirectConstructorToMethod("StardewValley.Locations.LibraryMuseum", "getRewardsForPlayer")]
+        [HookRedirectConstructorToMethod("StardewValley.Locations.Sewer", "populateShopStock")]
+        [HookRedirectConstructorToMethod("StardewValley.Object", "getOne")]
+        [HookRedirectConstructorToMethod("StardewValley.Object", "minutesElapsed")]
+        [HookRedirectConstructorToMethod("StardewValley.Objects.ObjectFactory", "getItemFromDescription")]
+        [HookRedirectConstructorToMethod("StardewValley.SlimeHutch", "DayUpdate")]
+        [HookRedirectConstructorToMethod("StardewValley.Utility", "generateNewFarm")]
+        [HookRedirectConstructorToMethod("StardewValley.Utility", "getAnimalShopStock")]
+        [HookRedirectConstructorToMethod("StardewValley.Utility", "getCarpenterStock")]
+        [HookRedirectConstructorToMethod("StardewValley.Utility", "getDwarfShopStock")]
+        [HookRedirectConstructorToMethod("StardewValley.Utility", "getItemFromStandardTextDescription")]
+        [HookRedirectConstructorToMethod("StardewValley.Utility", "getQiShopStock")]
+        [HookRedirectConstructorToMethod("StardewValley.Utility", "getTravelingMerchantStock")]
+        public static StardewValley.Object Create(Vector2 vector, int Id, bool isRecipe = false)
         {
-            Information = information;
-        }
-
-        [HookRedirectConstructorToMethod("StardewValley.Utility","tryToAddObjectToHome")]
-        public static StardewValley.Object Create(Vector2 vector, int Id, string name, bool canBeSetDown, bool canBeGrabbed, bool isHoeDirt, bool isSpawnedObject)
-        {
-            return new StardewValley.Object(vector, Id, name, canBeSetDown, canBeGrabbed, isHoeDirt, isSpawnedObject);
+            // Search for a big craftable with a custom type
+            foreach (BigCraftableInformation bigCraftable in BigCraftables)
+            {
+                if(bigCraftable.Id == Id)
+                {
+                    try
+                    {
+                        Type bigCraftableType = RegisteredIdType[Id];
+                        return (StardewValley.Object)Activator.CreateInstance(bigCraftableType, bigCraftable, vector, Id, isRecipe);
+                    }
+                    catch(Exception e)
+                    {
+                        Logging.Log.Error($"{e.Message}");
+                    }
+                }
+            }
+            // If there are none, just use a default object
+            return new StardewValley.Object(vector, Id, isRecipe);
         }
     }
 }

--- a/Libraries/Farmhand/API/Items/BigCraftable.cs
+++ b/Libraries/Farmhand/API/Items/BigCraftable.cs
@@ -1,4 +1,5 @@
 ﻿using Farmhand.API.Utilities;
+using Farmhand.Attributes;
 using Microsoft.Xna.Framework;
 using StardewValley;
 using System;
@@ -43,6 +44,12 @@ namespace Farmhand.API.Items
             base(Vector2.Zero, information.Id, false)
         {
             Information = information;
+        }
+
+        [HookRedirectConstructorToMethod("StardewValley.Utility","tryToAddObjectToHome")]
+        public static StardewValley.Object Create(Vector2 vector, int Id, string name, bool canBeSetDown, bool canBeGrabbed, bool isHoeDirt, bool isSpawnedObject)
+        {
+            return new StardewValley.Object(vector, Id, name, canBeSetDown, canBeGrabbed, isHoeDirt, isSpawnedObject);
         }
     }
 }

--- a/Libraries/Farmhand/API/Player/Player.cs
+++ b/Libraries/Farmhand/API/Player/Player.cs
@@ -50,16 +50,6 @@ namespace Farmhand.API.Player
             player.addItemToInventory(new T());
         }
 
-        public static void AddBigCraftable<T>(Farmer player = null) where T : Farmhand.API.Items.BigCraftable, new()
-        {
-            if (player == null)
-            {
-                player = Game1.player;
-            }
-
-            player.addItemToInventory(new T());
-        }
-
         public static void AddTool<T>(Farmer player = null) where T : StardewValley.Tool, new()
         {
             if (player == null)

--- a/Libraries/Farmhand/Attributes/HookRedirectConstructorToMethodAttribute.cs
+++ b/Libraries/Farmhand/Attributes/HookRedirectConstructorToMethodAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Farmhand.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public sealed class HookRedirectConstructorToMethodAttribute : Attribute
+    {
+        public HookRedirectConstructorToMethodAttribute(string type, string method, params Type[] genericArguments)
+        {
+            Type = type;
+            Method = method;
+            GenericArguments = genericArguments;
+        }
+
+        public HookRedirectConstructorToMethodAttribute(string type, string method)
+        {
+            Type = type;
+            Method = method;
+        }
+
+        public string Type { get; set; }
+        public string Method { get; set; }
+        public Type[] GenericArguments { get; set; }
+    }
+}

--- a/Libraries/Farmhand/Farmhand.csproj
+++ b/Libraries/Farmhand/Farmhand.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Attributes\HookMakeBaseVirtualCallAttribute.cs" />
     <Compile Include="Attributes\HookRedirectAttribute.cs" />
     <Compile Include="Attributes\HookRedirectConstructorFromBaseAttribute.cs" />
+    <Compile Include="Attributes\HookRedirectConstructorToMethodAttribute.cs" />
     <Compile Include="Attributes\HookReturnableAttribute.cs" />
     <Compile Include="Attributes\HookType.cs" />
     <Compile Include="Attributes\InputBindAttribute.cs" />

--- a/Libraries/Farmhand/Farmhand.csproj
+++ b/Libraries/Farmhand/Farmhand.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Overrides\Characters\Monster.cs" />
     <Compile Include="Overrides\Game1.cs" />
     <Compile Include="Overrides\SerializableDictionary.cs" />
+    <Compile Include="Overrides\StardewObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Registries\Containers\DependencyState.cs" />
     <Compile Include="Registries\Containers\ModContent.cs" />

--- a/Libraries/Farmhand/Overrides/StardewObject.cs
+++ b/Libraries/Farmhand/Overrides/StardewObject.cs
@@ -1,0 +1,14 @@
+﻿using Farmhand.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Farmhand.Overrides
+{
+    [HookForceVirtualBase]
+    [HookAlterBaseFieldProtection(LowestProtection.Protected)]
+    public class StardewObject : StardewValley.Object
+    {
+    }
+}

--- a/Libraries/FarmhandGame/FarmhandGame.csproj
+++ b/Libraries/FarmhandGame/FarmhandGame.csproj
@@ -63,6 +63,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Game1.cs" />
+    <Compile Include="Item\BigCraftable.cs" />
+    <Compile Include="Item\StardewObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializableDictionary.cs" />
   </ItemGroup>

--- a/Libraries/FarmhandGame/Item/BigCraftable.cs
+++ b/Libraries/FarmhandGame/Item/BigCraftable.cs
@@ -1,0 +1,30 @@
+﻿using Farmhand.API.Items;
+using Microsoft.Xna.Framework;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Xna.Framework.Graphics;
+using xTile.Dimensions;
+
+namespace Farmhand.Overrides.Game.Item
+{
+    public class BigCraftable : StardewObject
+    {
+        // Big Craftable Information
+        public BigCraftableInformation Information { get; set; }
+
+        public BigCraftable(BigCraftableInformation information) :
+            base(Vector2.Zero, information.Id, false)
+        {
+            Information = information;
+        }
+
+        public BigCraftable(BigCraftableInformation information, Vector2 vector, int Id, bool isRecipe = false) :
+            base(vector, Id, isRecipe)
+        {
+            Information = information;
+        }
+    }
+}

--- a/Libraries/FarmhandGame/Item/StardewObject.cs
+++ b/Libraries/FarmhandGame/Item/StardewObject.cs
@@ -1,0 +1,484 @@
+﻿using Farmhand.API.Items;
+using Microsoft.Xna.Framework;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Xna.Framework.Graphics;
+using xTile.Dimensions;
+
+namespace Farmhand.Overrides.Game.Item
+{
+    public class StardewObject : StardewValley.Object
+    {
+
+        // All the constructors offered by StardewValley.Object
+        public StardewObject() :
+            base()
+        {
+        }
+
+        public StardewObject(Vector2 vector, int Id, bool isRecipe = false) :
+            base(vector, Id, isRecipe)
+        {
+        }
+
+        public StardewObject(int parentSheetIndex, int initialStack, bool isRecipe = false, int price = -1, int quality = 0) :
+            base(parentSheetIndex, initialStack, isRecipe, price, quality)
+        {
+        }
+
+        public StardewObject(Vector2 tileLocation, int parentSheetIndex, int initialStack) :
+            base(tileLocation, parentSheetIndex, initialStack)
+        {
+        }
+
+        public StardewObject(Vector2 tileLocation, int parentSheetIndex, string name, bool canBeSetDown, bool canBeGrabbed, bool isHoedirt, bool isSpawnedObject) :
+            base(tileLocation, parentSheetIndex, name, canBeSetDown, canBeGrabbed, isHoedirt, isSpawnedObject)
+        {
+        }
+
+        // Overriden methods
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void actionOnPlayerEntry()
+        {
+            base.actionOnPlayerEntry();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void actionWhenBeingHeld(Farmer who)
+        {
+            base.actionWhenBeingHeld(who);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool actionWhenPurchased()
+        {
+            return base.actionWhenPurchased();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void actionWhenStopBeingHeld(Farmer who)
+        {
+            base.actionWhenStopBeingHeld(who);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override int addToStack(int amount)
+        {
+            return base.addToStack(amount);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void addWorkingAnimation(GameLocation environment)
+        {
+            base.addWorkingAnimation(environment);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool canBeGivenAsGift()
+        {
+            return base.canBeGivenAsGift();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool canBePlacedHere(GameLocation l, Vector2 tile)
+        {
+            return base.canBePlacedHere(l, tile);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool canBePlacedInWater()
+        {
+            return base.canBePlacedInWater();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool canBeShipped()
+        {
+            return base.canBeShipped();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool canBeTrashed()
+        {
+            return base.canBeTrashed();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool checkForAction(Farmer who, bool justCheckingForActivity = false)
+        {
+            return base.checkForAction(who, justCheckingForActivity);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override string checkForSpecialItemHoldUpMeessage()
+        {
+            return base.checkForSpecialItemHoldUpMeessage();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool clicked(Farmer who)
+        {
+            return base.clicked(who);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void consumeRecipe(Farmer who)
+        {
+            base.consumeRecipe(who);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool countsForShippedCollection()
+        {
+            return base.countsForShippedCollection();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void DayUpdate(GameLocation location)
+        {
+            base.DayUpdate(location);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void draw(SpriteBatch spriteBatch, int x, int y, float alpha = 1)
+        {
+            base.draw(spriteBatch, x, y, alpha);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void draw(SpriteBatch spriteBatch, int xNonTile, int yNonTile, float layerDepth, float alpha = 1)
+        {
+            base.draw(spriteBatch, xNonTile, yNonTile, layerDepth, alpha);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void drawAsProp(SpriteBatch b)
+        {
+            base.drawAsProp(b);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void drawInMenu(SpriteBatch spriteBatch, Vector2 location, float scaleSize, float transparency, float layerDepth, bool drawStackNumber)
+        {
+            base.drawInMenu(spriteBatch, location, scaleSize, transparency, layerDepth, drawStackNumber);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void drawPlacementBounds(SpriteBatch spriteBatch, GameLocation location)
+        {
+            base.drawPlacementBounds(spriteBatch, location);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void drawWhenHeld(SpriteBatch spriteBatch, Vector2 objectPosition, Farmer f)
+        {
+            base.drawWhenHeld(spriteBatch, objectPosition, f);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void farmerAdjacentAction()
+        {
+            base.farmerAdjacentAction();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override Microsoft.Xna.Framework.Rectangle getBoundingBox(Vector2 tileLocation)
+        {
+            return base.getBoundingBox(tileLocation);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override Color getCategoryColor()
+        {
+            return base.getCategoryColor();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override string getCategoryName()
+        {
+            return base.getCategoryName();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override string getDescription()
+        {
+            return base.getDescription();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override int getHealth()
+        {
+            return base.getHealth();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override Vector2 getLocalPosition(xTile.Dimensions.Rectangle viewport)
+        {
+            return base.getLocalPosition(viewport);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override StardewValley.Item getOne()
+        {
+            return base.getOne();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override Vector2 getScale()
+        {
+            return base.getScale();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override int getStack()
+        {
+            return base.getStack();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void hoverAction()
+        {
+            base.hoverAction();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void initializeLightSource(Vector2 tileLocation)
+        {
+            base.initializeLightSource(tileLocation);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool isActionable(Farmer who)
+        {
+            return base.isActionable(who);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool isAnimalProduct()
+        {
+            return base.isAnimalProduct();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool isForage(GameLocation location)
+        {
+            return base.isForage(location);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool isPassable()
+        {
+            return base.isPassable();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool isPlaceable()
+        {
+            return base.isPlaceable();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override int maximumStackSize()
+        {
+            return base.maximumStackSize();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool minutesElapsed(int minutes, GameLocation environment)
+        {
+            return base.minutesElapsed(minutes, environment);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool onExplosion(Farmer who, GameLocation location)
+        {
+            return base.onExplosion(who, location);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool performDropDownAction(Farmer who)
+        {
+            return base.performDropDownAction(who);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool performObjectDropInAction(StardewValley.Object dropIn, bool probe, Farmer who)
+        {
+            return base.performObjectDropInAction(dropIn, probe, who);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void performRemoveAction(Vector2 tileLocation, GameLocation environment)
+        {
+            base.performRemoveAction(tileLocation, environment);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool performToolAction(Tool t)
+        {
+            return base.performToolAction(t);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool performUseAction()
+        {
+            return base.performUseAction();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override bool placementAction(GameLocation location, int x, int y, Farmer who = null)
+        {
+            return base.placementAction(location, x, y, who);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void reloadSprite()
+        {
+            base.reloadSprite();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void rot()
+        {
+            base.rot();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override int salePrice()
+        {
+            return base.salePrice();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override int sellToStorePrice()
+        {
+            return base.sellToStorePrice();
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void setHealth(int health)
+        {
+            base.setHealth(health);
+        }
+
+        /// <summary>
+        /// Calling conditions, usage, and return value significance unkown
+        /// </summary>
+        public override void updateWhenCurrentLocation(GameTime time)
+        {
+            base.updateWhenCurrentLocation(time);
+        }
+    }
+}

--- a/Mods/TestBigCraftableMod/BigCraftables/TestBigCraftable.cs
+++ b/Mods/TestBigCraftableMod/BigCraftables/TestBigCraftable.cs
@@ -1,8 +1,10 @@
 ﻿using Farmhand.API.Items;
+using Microsoft.Xna.Framework;
+using StardewValley;
 
 namespace TestBigCraftableMod.BigCraftables
 {
-    public class TestBigCraftable : BigCraftable
+    public class TestBigCraftable : Farmhand.Overrides.Game.Item.BigCraftable
     {
         private static BigCraftableInformation _information;
         public static BigCraftableInformation StaticInformation => _information ?? (_information = new Farmhand.API.Items.BigCraftableInformation
@@ -24,6 +26,18 @@ namespace TestBigCraftableMod.BigCraftables
             base(StaticInformation)
         {
 
+        }
+
+        public TestBigCraftable(BigCraftableInformation information, Vector2 vector, int Id, bool isRecipe = false) :
+            base(information, vector, Id, isRecipe)
+        {
+            Information = information;
+        }
+
+        public override bool clicked(Farmer who)
+        {
+            Farmhand.Logging.Log.Success("Test Big Craftable Overriding Clicked Event!");
+            return base.clicked(who);
         }
     }
 }

--- a/Mods/TestBigCraftableMod/TestBigCraftableMod.cs
+++ b/Mods/TestBigCraftableMod/TestBigCraftableMod.cs
@@ -25,7 +25,7 @@ namespace TestBigCraftableMod
 
         private void PlayerEvents_OnFarmerChanged(object sender, System.EventArgs e)
         {
-            Farmhand.API.Player.Player.AddBigCraftable<TestBigCraftable>();
+            Farmhand.API.Player.Player.AddObject<TestBigCraftable>();
         }
     }
 }

--- a/Mods/TestBigCraftableMod/TestBigCraftableMod.csproj
+++ b/Mods/TestBigCraftableMod/TestBigCraftableMod.csproj
@@ -35,6 +35,9 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
       <Private>False</Private>
     </Reference>


### PR DESCRIPTION
- Added a new type of hook attribute that allows a constructor to be
redirected and instead use a method which returns the same type of
object and takes the same parameters. This hook will allow creation of
factories where appropriate.

- An example usage I will be utilizing more fully later is in
BigCraftables.cs, where the constructor for a StardewValley.Object
object is redirected to use a method instead

- Used the new redirect constructor to method hook, a factory was set up
which assures that mods which use a type which extends BigCraftable gets
that object instantiated for its big craftables

- Added an override during the first pass called StardewObject, whos
base class is StardewValley.Object. This override does the standard job
of forcing virtual base and setting the lowest field level to protected,
to make way for the second pass library StardewObject to do it's job

- Created a class in the second pass library Game called StardewObject
which extends from StardewValley.Object with a slight name change to
StardewObject to avoid confusion. All overridable methods were listed in
this class in order to provide opportunities for documentation

- Moved the override for BigCraftables to the Game second pass library,
and changed its base class to StardewObject

- The BigCraftable static elements that allow registration of new
BigCraftable information and types, as well as hosting the factory,
stayed behind during the new BigCraftable move to the second pass
library

- Removed AddBigCraftable from Farmhand.API.Player.Player, as AddObject
does the exact same job

- Fixed Big Craftables example mod to use these new standards, and added
an example method override that displays a message in the debugger
whenever it is left clicked