### PR TITLE
Extend stardew localization handling into xnb files loaded by FarmHand

### DIFF
--- a/Libraries/Farmhand/Content/ContentManager.cs
+++ b/Libraries/Farmhand/Content/ContentManager.cs
@@ -42,6 +42,10 @@ namespace Farmhand.Content
         {
             return base.Load<T>(assetName);
         }
+        public StardewValley.LocalizedContentManager CreateContentManager(string rootDirectory)
+        {
+            return new StardewValley.LocalizedContentManager(ServiceProvider, rootDirectory, CurrentCulture, LanguageCodeOverride);
+        }
 
         /// <summary>
         /// Load an asset by via a relative (extensionless) path

--- a/Libraries/Farmhand/Content/ModXnbInjector.cs
+++ b/Libraries/Farmhand/Content/ModXnbInjector.cs
@@ -16,7 +16,7 @@ namespace Farmhand.Content
         public bool IsLoader => true;
         public bool IsInjector => false;
 
-        private static List<Microsoft.Xna.Framework.Content.ContentManager> _modManagers;
+        private static List<StardewValley.LocalizedContentManager> _modManagers;
         private readonly Dictionary<string, Texture2D> _cachedAlteredTextures = new Dictionary<string, Texture2D>();
 
         public bool HandlesAsset(Type type, string assetName)
@@ -73,14 +73,14 @@ namespace Farmhand.Content
         {
             if (_modManagers != null) return;
 
-            _modManagers = new List<Microsoft.Xna.Framework.Content.ContentManager>();
+            _modManagers = new List<StardewValley.LocalizedContentManager>();
             foreach (var modPath in ModLoader.ModPaths)
             {
-                _modManagers.Add(new Microsoft.Xna.Framework.Content.ContentManager(contentManager.ServiceProvider, modPath));
+                _modManagers.Add(contentManager.CreateContentManager(modPath));
             }
         }
 
-        private Microsoft.Xna.Framework.Content.ContentManager GetContentManagerForMod(ContentManager contentManager, ModXnb mod)
+        private StardewValley.LocalizedContentManager GetContentManagerForMod(ContentManager contentManager, ModXnb mod)
         {
             LoadModManagers(contentManager);
             return _modManagers.FirstOrDefault(n => mod.OwningMod.ModDirectory.Contains(n.RootDirectory));


### PR DESCRIPTION
Extends localization handling as Stardew does it into xnb files loaded by FarmHand, in preparation for Stardew 1.2 where localization actually gets used rather then just hidden in the code.