### PR TITLE
Map Merging Improvements

### DIFF
--- a/Libraries/Farmhand/API/Locations/MapInformation.cs
+++ b/Libraries/Farmhand/API/Locations/MapInformation.cs
@@ -3,13 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using xTile;
+using xTile.Layers;
 
 namespace Farmhand.API.Locations
 {
     public enum MapOverride
     {
-        PartialOverride,
-        FullOverride
+        SoftMerge,          // When merging, allow other maps to override this maps changes without conflict
+        NormalMerge,        // When merging, use regular merging rules
+        FullOverride        // When merging, use ONLY this map, ignore other maps
     }
 
     public class MapInformation
@@ -18,13 +20,78 @@ namespace Farmhand.API.Locations
 
         public Map Map { get; set; }
 
-        public MapOverride Override { get; set; } = MapOverride.PartialOverride;
+        public MapOverride Override { get; set; } = MapOverride.NormalMerge;
 
-        public MapInformation(Mod owner, Map map, MapOverride @override = MapOverride.PartialOverride)
+        public int OffsetX { get; set; } = 0;
+
+        public int OffsetY { get; set; } = 0;
+
+        public MapInformation(Mod owner, Map map, MapOverride @override = MapOverride.NormalMerge)
         {
             Owner = owner;
             Map = map;
             Override = @override;
+
+            CheckWarnings();
+        }
+
+        public MapInformation(Mod owner, Map map, int offsetX, int offsetY, MapOverride @override = MapOverride.NormalMerge)
+        {
+            Owner = owner;
+            Map = map;
+            Override = @override;
+            OffsetX = offsetX;
+            OffsetY = offsetY;
+
+            CheckWarnings();
+        }
+
+        // Check for warnings about this map
+        private void CheckWarnings()
+        {
+            // Check for a negative offset, and issue a warning
+            if (OffsetX < 0 || OffsetY < 0)
+            {
+                Farmhand.Logging.Log.Warning($"Map information registered with a negative offset by mod {Owner.ModSettings.Name}, I hope {Owner.ModSettings.Author} knows what they're doing...");
+            }
+
+            // Check for a map that's too large, and issue a warning
+            if (TotalWidth() > 155 || TotalHeight() > 155 || TotalWidth() + OffsetX > 155 || TotalHeight() + OffsetY > 155)
+            {
+                Farmhand.Logging.Log.Warning($"Map information registered with a size larger than 155 tiles by mod {Owner.ModSettings.Name}, Using this map will probably crash the game!");
+            }
+        }
+
+        // Get the width for this map
+        public int TotalWidth()
+        {
+            int width = 0;
+
+            foreach(Layer layer in Map.Layers)
+            {
+                if(layer.LayerWidth > width)
+                {
+                    width = layer.LayerWidth;
+                }
+            }
+
+            return width;
+        }
+
+        // Get the height for this map
+        public int TotalHeight()
+        {
+            int height = 0;
+
+            foreach (Layer layer in Map.Layers)
+            {
+                if (layer.LayerHeight > height)
+                {
+                    height = layer.LayerHeight;
+                }
+            }
+
+            return height;
         }
     }
 }


### PR DESCRIPTION
- Changed parameters to allow mods to independently request maps
provided to be merged and returned. It's not just for internal use
anymore!

- Added "SoftMerge" to the MapOverride enum, when a MapInformation
object is tagged with it, any tile conflicts it has with another map
will resolve to use the other map's changes, without throwing a warning

- Allowed MapInformation to specify an offset for the map to use,
displacing the map from 0,0. A warning will be displayed at a negative
offset, but it shouldn't cause outright errors. This will mainly come in
handy for small "sub-maps" to be merged together onto one bigger map.

- Created a warning that will be displayed if a MapInformation is
created that, between the size of the map and the offset used, would
create a map bigger than 155x155, which Entoarox says will crash the
game if used.

- Stored maps which have already been merged internally, so that they
don't have to be redundantly merged again later. This storage doesn't
apply to the maps merged for mods upon request.