### PR TITLE
Added missing SMAPI event OnMenuClosed

### DIFF
--- a/Libraries/Farmhand/Events/Arguments/MenuEvents/EventArgsOnMenuChanged.cs
+++ b/Libraries/Farmhand/Events/Arguments/MenuEvents/EventArgsOnMenuChanged.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using StardewValley.Menus;
+
+namespace Farmhand.Events.Arguments.MenuEvents
+{
+    public class EventArgsOnMenuChanged : EventArgs
+    {
+        public EventArgsOnMenuChanged(IClickableMenu priorMenu, IClickableMenu newMenu)
+        {
+            PriorMenu = priorMenu;
+            NewMenu = newMenu;
+        }
+
+        public IClickableMenu PriorMenu { get; set; }
+        public IClickableMenu NewMenu { get; set; }
+    }
+}

--- a/Libraries/Farmhand/Events/MenuEvents.cs
+++ b/Libraries/Farmhand/Events/MenuEvents.cs
@@ -1,4 +1,5 @@
 ﻿using Farmhand.Attributes;
+using Farmhand.Events.Arguments.MenuEvents;
 using StardewValley.Menus;
 using System;
 
@@ -9,12 +10,12 @@ namespace Farmhand.Events
     /// </summary>
     public static class MenuEvents
     {
-        public static event EventHandler OnMenuChanged = delegate { };
+        public static event EventHandler<EventArgsOnMenuChanged> OnMenuChanged = delegate { };
         
         [PendingHook]
         internal static void InvokeMenuChanged(IClickableMenu priorMenu, IClickableMenu newMenu)
         {
-            EventCommon.SafeInvoke(OnMenuChanged, null);
+            EventCommon.SafeInvoke(OnMenuChanged, null, new EventArgsOnMenuChanged(priorMenu, newMenu));
         }
     }
 }

--- a/Libraries/Farmhand/Farmhand.csproj
+++ b/Libraries/Farmhand/Farmhand.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Events\Arguments\GlobalRoute\EventArgsGlobalRouteReturnable.cs" />
     <Compile Include="Events\Arguments\GraphicsEvents\EventArgsClientSizeChanged.cs" />
     <Compile Include="Events\Arguments\LocationEvents\EventArgsGetMonsterForThisLevel.cs" />
+    <Compile Include="Events\Arguments\MenuEvents\EventArgsOnMenuChanged.cs" />
     <Compile Include="Events\Arguments\PlayerEvents\EventArgsOnFarmerChanged.cs" />
     <Compile Include="Events\Arguments\PlayerEvents\EventArgsOnItemAddedToInventory.cs" />
     <Compile Include="Events\Arguments\PlayerEvents\EventArgsOnLevelUp.cs" />

--- a/Libraries/SmapiCompatibilityLayer/Events/EventArgs.cs
+++ b/Libraries/SmapiCompatibilityLayer/Events/EventArgs.cs
@@ -108,6 +108,16 @@ namespace StardewModdingAPI.Events
         public IClickableMenu PriorMenu { get; private set; }
     }
 
+    public class EventArgsClickableMenuClosed : EventArgs
+    {
+        public EventArgsClickableMenuClosed(IClickableMenu priorMenu)
+        {
+            PriorMenu = priorMenu;
+        }
+        
+        public IClickableMenu PriorMenu { get; private set; }
+    }
+
     public class EventArgsGameLocationsChanged : EventArgs
     {
         public EventArgsGameLocationsChanged(List<GameLocation> newLocations)

--- a/Libraries/SmapiCompatibilityLayer/Events/Menu.cs
+++ b/Libraries/SmapiCompatibilityLayer/Events/Menu.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using StardewValley;
 using Farmhand.Events;
+using Farmhand.Events.Arguments.MenuEvents;
 
 namespace StardewModdingAPI.Events
 {
@@ -8,9 +9,9 @@ namespace StardewModdingAPI.Events
     {
         public static event EventHandler<EventArgsClickableMenuChanged> MenuChanged = delegate { };
 
-        internal static void InvokeMenuChanged(object sender, EventArgs eventArgs)
+        internal static void InvokeMenuChanged(object sender, EventArgsOnMenuChanged eventArgs)
         {
-            EventCommon.SafeInvoke(MenuChanged, null, new EventArgsClickableMenuChanged(null, Game1.activeClickableMenu));
+            EventCommon.SafeInvoke(MenuChanged, null, new EventArgsClickableMenuChanged(eventArgs.PriorMenu, eventArgs.NewMenu));
         }
     }
 }

--- a/Libraries/SmapiCompatibilityLayer/Events/Menu.cs
+++ b/Libraries/SmapiCompatibilityLayer/Events/Menu.cs
@@ -8,10 +8,14 @@ namespace StardewModdingAPI.Events
     public static class MenuEvents
     {
         public static event EventHandler<EventArgsClickableMenuChanged> MenuChanged = delegate { };
+        public static event EventHandler<EventArgsClickableMenuClosed> MenuClosed = delegate { };
 
         internal static void InvokeMenuChanged(object sender, EventArgsOnMenuChanged eventArgs)
         {
-            EventCommon.SafeInvoke(MenuChanged, null, new EventArgsClickableMenuChanged(eventArgs.PriorMenu, eventArgs.NewMenu));
+            if ( eventArgs.PriorMenu != null && eventArgs.NewMenu == null)
+                EventCommon.SafeInvoke(MenuClosed, null, new EventArgsClickableMenuClosed(eventArgs.PriorMenu));
+            else
+                EventCommon.SafeInvoke(MenuChanged, null, new EventArgsClickableMenuChanged(eventArgs.PriorMenu, eventArgs.NewMenu));
         }
     }
 }


### PR DESCRIPTION
Requires #118.

(I have no clue if I can/should even do it like this, seeing as this shows both commits on here.)

I haven't tested it much - I noticed one of my mods failed to load from this event being missing, but when I changed branches the #117 changes went away. It doesn't crash the game though, and I don't see why it wouldn't work.