### PR TITLE
Made SMAPI PlayerEvents.LoadedGame fire.

### DIFF
--- a/Libraries/SmapiCompatibilityLayer/Compatibility.cs
+++ b/Libraries/SmapiCompatibilityLayer/Compatibility.cs
@@ -47,6 +47,7 @@ namespace StardewModdingAPI
 #pragma warning restore CS0618
 
             Farmhand.Events.LocationEvents.OnLocationsChanged += Events.LocationEvents.InvokeLocationsChanged;
+            Farmhand.Events.LocationEvents.OnLocationsChanged += Events.PlayerEvents.InvokeLoadedGame;
             Farmhand.Events.LocationEvents.OnLocationObjectsChanged += Events.LocationEvents.InvokeOnNewLocationObject;
             Farmhand.Events.LocationEvents.OnCurrentLocationChanged += Events.LocationEvents.InvokeCurrentLocationChanged;
 

--- a/Libraries/SmapiCompatibilityLayer/Events/Player.cs
+++ b/Libraries/SmapiCompatibilityLayer/Events/Player.cs
@@ -27,9 +27,9 @@ namespace StardewModdingAPI.Events
             EventCommon.SafeInvoke(LeveledUp, sender, new EventArgsLevelUp(eventArgsOnLevelUp.Which, eventArgsOnLevelUp.NewLevel));
         }
 
-        internal static void InvokeLoadedGame(EventArgsLoadedGameChanged loaded)
+        internal static void InvokeLoadedGame(object sender, EventArgs eventArgs)
         {
-            EventCommon.SafeInvoke(LoadedGame, null, loaded);
+            EventCommon.SafeInvoke(LoadedGame, null, new EventArgsLoadedGameChanged(true));
         }
     }
 }


### PR DESCRIPTION
This event wasn't ever fired, which breaks some mods (NPCMapLocations).

While SMAPI ordinarily just monitors Game1.hasLoadedGame, the only time this ever changes is at the end of loadForNewGame. Since the Farmhand LocationsChanged already triggers her, I just hooked it into there.

This could break if future game versions (or a mod?) lets you exit back to the main menu, or I suppose anything about that variable assignment changes.