### PR TITLE
Added event for overriding whether time passes or not.

### DIFF
--- a/Libraries/Farmhand/Events/Arguments/TimeEvents/EventArgsShouldTimePassCheck.cs
+++ b/Libraries/Farmhand/Events/Arguments/TimeEvents/EventArgsShouldTimePassCheck.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Farmhand.Events.Arguments.TimeEvents
+{
+    public class EventArgsShouldTimePassCheck : EventArgs
+    {
+        public EventArgsShouldTimePassCheck( bool timeShouldPass )
+        {
+            TimeShouldPass = timeShouldPass;
+        }
+
+        public bool TimeShouldPass { get; set; }
+    }
+}

--- a/Libraries/Farmhand/Events/GameEvents.cs
+++ b/Libraries/Farmhand/Events/GameEvents.cs
@@ -66,6 +66,7 @@ namespace Farmhand.Events
         [Hook(HookType.Exit, "StardewValley.Game1", "Update")]
         internal static void InvokeAfterUpdate([ThisBind] object @this)
         {
+            TimeEvents.didShouldTimePassCheckThisFrame = false;
             EventCommon.SafeInvoke(OnAfterUpdateTick, @this);
         }
     }

--- a/Libraries/Farmhand/Farmhand.csproj
+++ b/Libraries/Farmhand/Farmhand.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Events\Arguments\PlayerEvents\EventArgsOnLevelUp.cs" />
     <Compile Include="Events\Arguments\SaveEvents\EventArgsOnAfterLoad.cs" />
     <Compile Include="Events\Arguments\SaveEvents\EventArgsOnBeforeLoad.cs" />
+    <Compile Include="Events\Arguments\TimeEvents\EventArgsShouldTimePassCheck.cs" />
     <Compile Include="Events\Arguments\UtilityEvents\EventArgsOnGetDwarfShopStock.cs" />
     <Compile Include="Events\ControlEvents.cs" />
     <Compile Include="Events\EventCommon.cs" />


### PR DESCRIPTION
It works a bit differently than most events. I wasn't sure about the performance of this (since the function is called over <# of NPCs + # of farm animals> times per frame), so I made it so that it only calls the event the first time each frame, and reuses that value until the next frame.

For an example, see 5d7530f. (I also plan on using this later on when I port the MP mod.)