### PR TITLE
Added OnEventFinished event.

### DIFF
--- a/Libraries/Farmhand/Events/EventEvents.cs
+++ b/Libraries/Farmhand/Events/EventEvents.cs
@@ -1,0 +1,23 @@
+﻿using Farmhand.Attributes;
+using Farmhand.Events.Arguments.LocationEvents;
+using StardewValley;
+using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace Farmhand.Events
+{
+    /// <summary>
+    /// Contains events relating to (in-game) events
+    /// </summary>
+    public static class EventEvents
+    {
+        public static event EventHandler OnEventFinished = delegate { };
+        
+        [Hook(HookType.Entry, "StardewValley.Event", "exitEvent")]
+        internal static void InvokeOnBeforeLocationLoadObjects([ThisBind] object @this)
+        {
+            EventCommon.SafeInvoke(OnEventFinished, @this);
+        }
+    }
+}

--- a/Libraries/Farmhand/Farmhand.csproj
+++ b/Libraries/Farmhand/Farmhand.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Events\GameEvents.cs" />
     <Compile Include="Events\GlobalRouteManager.cs" />
     <Compile Include="Events\GraphicsEvents.cs" />
+    <Compile Include="Events\EventEvents.cs" />
     <Compile Include="Events\LocationEvents.cs" />
     <Compile Include="Events\MenuEvents.cs" />
     <Compile Include="Events\MineShaftEvents.cs" />


### PR DESCRIPTION
This way a mod can (for example, what I did during testing) set Game.locationAfterWarp / x/yLocationAfterWarp when an event is finished.

I believe this is triggered before the fading actually occurs.