### PR TITLE
Enabled SMAPI Logger.AsyncColour

### DIFF
--- a/Libraries/SmapiCompatibilityLayer/Logger.cs
+++ b/Libraries/SmapiCompatibilityLayer/Logger.cs
@@ -62,7 +62,7 @@ namespace StardewModdingAPI
 
         public static void AsyncColour(object message, ConsoleColor colour)
         {
-            //Task.Run(() => { PrintLog(new LogInfo(message?.ToString(), colour)); });
+            System.Threading.Tasks.Task.Factory.StartNew(() => { PrintLog(new LogInfo(message?.ToString(), colour)); });
         }
 
         public static void Async(object message)


### PR DESCRIPTION
This lets all of the Logger.Async<...> calls work.

This is pretty important for debugging SMAPI compatibility issues.