### PR TITLE
Load cross-platform mods

### DIFF
--- a/Libraries/Farmhand/Farmhand.csproj
+++ b/Libraries/Farmhand/Farmhand.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Events\UtilityEvents.cs" />
     <Compile Include="FarmhandConfig.cs" />
     <Compile Include="Helpers\ArgumentsHelper.cs" />
+    <Compile Include="Mods\ReferenceFix.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Helpers\ExtensionMethods.cs" />
     <Compile Include="Helpers\CompatibilityLayer.cs" />

--- a/Libraries/Farmhand/Farmhand.csproj
+++ b/Libraries/Farmhand/Farmhand.csproj
@@ -80,6 +80,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Xml" />
     <Reference Include="xTile">
       <HintPath>..\..\WorkingDirectory\xTile.dll</HintPath>

--- a/Libraries/Farmhand/FarmhandConfig.cs
+++ b/Libraries/Farmhand/FarmhandConfig.cs
@@ -3,5 +3,6 @@
     public class FarmhandConfig
     {
         public bool DebugMode { get; set; }
+        public bool CachePorts { get; set; } = true;
     }
 }

--- a/Libraries/Farmhand/Mods/ModLoader.cs
+++ b/Libraries/Farmhand/Mods/ModLoader.cs
@@ -212,10 +212,10 @@ namespace Farmhand
                 }
             }
 
-            // See ReferenceFixers.cs
+            // See ReferenceFix.Data.BuildXnaTypeCache()
             // Since mod loading is done we don't need this anymore.
             // There are a lot of types, so might as well save the memory.
-            ReferenceFixData.xnaTypes.Clear();
+            ReferenceFix.Data.xnaTypes.Clear();
         }
 
         private static void ResolveDependencies()

--- a/Libraries/Farmhand/Mods/ModLoader.cs
+++ b/Libraries/Farmhand/Mods/ModLoader.cs
@@ -211,6 +211,11 @@ namespace Farmhand
                     ApiEvents.InvokeModLoadError(mod);
                 }
             }
+
+            // See ReferenceFixers.cs
+            // Since mod loading is done we don't need this anymore.
+            // There are a lot of types, so might as well save the memory.
+            ReferenceFixData.xnaTypes.Clear();
         }
 
         private static void ResolveDependencies()

--- a/Libraries/Farmhand/Mods/ReferenceFix.cs
+++ b/Libraries/Farmhand/Mods/ReferenceFix.cs
@@ -10,203 +10,62 @@ using System.Text;
 // "unreachable code detected" from keeping the thing from compiling.
 #pragma warning disable 0162
 
-namespace Farmhand
+using static Farmhand.ReferenceFix.Data;
+
+namespace Farmhand.ReferenceFix
 {
-    internal static class ReferenceFixData
+    internal static class Data
     {
         internal const bool WINDOWS = true;
-
-        internal static AssemblyNameReference fixRef(string @ref) { return fixRef(AssemblyNameReference.Parse(@ref)); }
-        internal static AssemblyNameReference fixRef(AssemblyNameReference @ref)
-        {
-            if (isStardew(@ref))
-                return thisRef;
-
-            if (!WINDOWS && isXna(@ref))
-            {
-                return monoRef;
-            }
-            else if (WINDOWS && isMono(@ref))
-            {
-                // Okay, I really have no clue what to do here, since the mapping for mono/xna is
-                // MonoGame.Framework <=> Microsoft.Xna.Framework(|.Game|.Graphics)
-                // I'm hoping the metadata resolver will help with this
-                return xnaRef;
-            }
-
-            return @ref;
-        }
 
         // If referencing vanilla Stardew, it wasn't built for Farmhand.
         // If on Windows and referencing Mono, it won't be compatible.
         // If not on Windows and referencing Microsoft XNA, it won't be compatible.
         // If none of these are true, everything is fine.
-        internal static bool matchesPlatform(AssemblyNameReference asmRef)
+        internal static bool MatchesPlatform(AssemblyNameReference asmRef)
         {
-            return !(isStardew(asmRef) ||
-                     WINDOWS && isMono(asmRef) ||
-                     !WINDOWS && isXna(asmRef));
+            return !(IsStardew(asmRef.Name) ||
+                     WINDOWS && IsMono(asmRef.Name) ||
+                     !WINDOWS && IsXna(asmRef.Name));
         }
 
-        internal static bool matchesPlatform(TypeReference asmRef)
+        internal static bool MatchesPlatform(TypeReference asmRef)
         {
-            return (isStardew(asmRef.Namespace) ||
-                    WINDOWS && isMono(asmRef.Namespace) ||
-                    !WINDOWS && isXna(asmRef.Namespace));
+            return (IsStardew(asmRef.Namespace) ||
+                    WINDOWS && IsMono(asmRef.Namespace) ||
+                    !WINDOWS && IsXna(asmRef.Namespace));
         }
 
-        private static FieldInfo typeRefField = typeof(TypeSpecification).GetField("scope", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static FieldInfo typeSpecField = typeof(TypeSpecification).GetField("element_type", BindingFlags.NonPublic | BindingFlags.Instance);
-        internal static TypeReference fixType(ModuleDefinition def, TypeReference type)
+        internal static bool IsStardew(string @ref)
         {
-            string from = type.Scope.Name;
-
-            TypeReference ret = type;
-            if (ret.GetType() == typeof(TypeReference))
-            {
-                if (isStardew(from))
-                    ret = new TypeReference(type.Namespace, type.Name, null, thisRef);
-                else if (!WINDOWS && isXna(from))
-                    ret = new TypeReference(type.Namespace, type.Name, null, monoRef);
-                else if (WINDOWS && isMono(from))
-                    ret = new TypeReference(type.Namespace, type.Name, null, findXnaRef(type));
-                ret.IsValueType = type.IsValueType;
-            }
-            else if (ret.GetType() == typeof(GenericParameter))
-                return fixGeneric(def, ret.DeclaringType, ret as GenericParameter);
-            else if (ret is TypeSpecification)
-                typeSpecField.SetValue(type, fixType(def, (type as TypeSpecification).ElementType));
-            else if (!(ret is TypeDefinition)) // Meaning it is defined in this assembly. I think?
-                Logging.Log.Warning("DON'T KNOW HOW TO DEAL WITH " + ret.GetType() + " " + ret);
-
-            if (type is GenericInstanceType)
-            {
-                for (int i = 0; i < (type as GenericInstanceType).ElementType.GenericParameters.Count; ++i)
-                {
-                    var t = (type as GenericInstanceType).ElementType.GenericParameters[i];
-                    (type as GenericInstanceType).ElementType.GenericParameters[i] = fixGeneric(def, type, t);
-                }
-                for (int i = 0; i < (type as GenericInstanceType).GenericArguments.Count; ++i)
-                {
-                    var t = (type as GenericInstanceType).GenericArguments[i];
-                    (type as GenericInstanceType).GenericArguments[i] = fixType(def, t);
-                }
-            }
-            else if ( type.HasGenericParameters )
-            {
-                for (int i = 0; i < type.GenericParameters.Count; ++i)
-                    type.GenericParameters[i] = fixGeneric(def, type, type.GenericParameters[i]);
-            }
-
-            return def.Import( ret );
-        }
-
-        private static FieldInfo methSpecField = typeof(MethodSpecification).GetField("method", BindingFlags.NonPublic | BindingFlags.Instance);
-        internal static MethodReference fixMethod(ModuleDefinition def, MethodReference meth)
-        {
-            foreach (var param in meth.Parameters)
-                param.ParameterType = fixType(def, param.ParameterType);
-
-            if (meth is GenericInstanceMethod)
-            {
-                var gim = (meth as GenericInstanceMethod);
-                methSpecField.SetValue(meth, fixMethod(def, gim.ElementMethod));
-                for (int i = 0; i < gim.GenericParameters.Count; ++i)
-                    gim.GenericParameters[i] = fixGeneric(def, meth, gim.GenericParameters[i]);
-                for (int i = 0; i < gim.GenericArguments.Count; ++i)
-                {
-                    gim.GenericArguments[i] = fixType(def, gim.GenericArguments[i]);
-                }
-            }
-            else if (meth.HasGenericParameters)
-            {
-                for (int i = 0; i < meth.GenericParameters.Count; ++i)
-                    meth.GenericParameters[i] = fixGeneric(def, meth, meth.GenericParameters[i]);
-            }
-            
-            meth.ReturnType = fixType(def, meth.ReturnType);
-            if (meth is MethodSpecification)
-            {
-                MethodReference elem = (methSpecField.GetValue(meth) as MethodReference);
-                methSpecField.SetValue(meth, fixMethod(def, elem));
-            }
-            else
-                meth.DeclaringType = fixType(def, meth.DeclaringType);
-            return def.Import(meth);
-        }
-
-        internal static FieldReference fixField(ModuleDefinition def, FieldReference field)
-        {
-            field.DeclaringType = fixType(def, field.DeclaringType);
-            field.FieldType = fixType(def, field.FieldType);
-            return def.Import(field);
-        }
-
-        private static FieldInfo genDeclOwner = typeof(GenericParameter).GetField("owner", BindingFlags.NonPublic | BindingFlags.Instance);
-        internal static GenericParameter fixGeneric( ModuleDefinition def, IGenericParameterProvider parent, GenericParameter param )
-        {
-            for (int i = 0; i < param.Constraints.Count; ++i)
-                param.Constraints[i] = fixType(def, param.Constraints[i]);
-            for (int i = 0; i < param.GenericParameters.Count; ++i)
-                param.GenericParameters[i] = fixGeneric(def, param, param.GenericParameters[i]);
-            /*
-            if (param.DeclaringType != null)
-                genDeclOwner.SetValue(param, fixType(def, param.DeclaringType));
-            else if (param.DeclaringMethod != null)
-                genDeclOwner.SetValue(param, fixMethod(def, param.DeclaringMethod));
-            //*/
-            return param;
-        }
-
-        private static IMetadataScope findXnaRef(TypeReference type)
-        {
-            string key = type.Namespace + "." + type.Name;
-            if (!xnaTypes.ContainsKey(key))
-                return xnaRef;
-                //Logging.Log.Error("NO XNA KEY " + key + " " + type + " " + type.Scope + " " + type.DeclaringType + " " + Environment.StackTrace);
-
-            return xnaTypes[ key ];
-        }
-
-        internal static bool isStardew(string @ref)
-        {
-           return @ref.StartsWith( "Stardew Valley" ) || @ref.StartsWith( "StardewValley" );
-        }
-        internal static bool isStardew(AssemblyNameReference @ref)
-        {
-            return @ref.Name == "Stardew Valley" || @ref.Name == "StardewValley";
+            // "Stardew Valley" on Windows, "StardewValley" otherwise.
+            // However, both end up being wrong since they should be referencing Farmhand.
+           return @ref.StartsWith("Stardew Valley") || @ref.StartsWith("StardewValley");
         }
 
         // Can't compare to static vars because they are null for the opposite platform
-        internal static bool isXna(string @ref)
+        internal static bool IsXna(string @ref)
         {
             return @ref.StartsWith("Microsoft.Xna.Framework");
         }
-        internal static bool isXna( AssemblyNameReference @ref )
-        {
-            return @ref.Name == "Microsoft.Xna.Framework" || @ref.Name == "Microsoft.Xna.Framework.Game" || @ref.Name == "Microsoft.Xna.Framework.Graphics";
-        }
-
-        internal static bool isMono(string @ref)
+        internal static bool IsMono(string @ref)
         {
             return @ref.StartsWith("MonoGame.Framework");
         }
-        internal static bool isMono( AssemblyNameReference @ref )
-        {
-            return @ref.Name == "MonoGame.Framework";
-        }
 
         internal static AssemblyNameReference thisRef = AssemblyNameReference.Parse(Assembly.GetExecutingAssembly().FullName);
-        internal static AssemblyNameReference monoRef = findMyRef("MonoGame.Framework");
-        internal static AssemblyNameReference xnaRef = findMyRef("Microsoft.Xna.Framework");
-        internal static AssemblyNameReference xnaGameRef = findMyRef("Microsoft.Xna.Framework.Game");
-        internal static AssemblyNameReference xnaGraphicsRef = findMyRef("Microsoft.Xna.Framework.Graphics");
+        internal static AssemblyNameReference monoRef = FindMyRef("MonoGame.Framework");
+        internal static AssemblyNameReference xnaRef = FindMyRef("Microsoft.Xna.Framework");
+        internal static AssemblyNameReference xnaGameRef = FindMyRef("Microsoft.Xna.Framework.Game");
+        internal static AssemblyNameReference xnaGraphicsRef = FindMyRef("Microsoft.Xna.Framework.Graphics");
 
-        internal static AssemblyNameReference findMyRef( string name )
+        // Find the references that we use. Technically could have hard-coded these to
+        // what Farmhand uses right now, but this is a bit more future-proof.
+        internal static AssemblyNameReference FindMyRef(string name)
         {
-            foreach ( var @ref in Assembly.GetExecutingAssembly().GetReferencedAssemblies() )
+            foreach (var @ref in Assembly.GetExecutingAssembly().GetReferencedAssemblies())
             {
-                if ( @ref.Name == name )
+                if (@ref.Name == name)
                 {
                     return AssemblyNameReference.Parse(@ref.FullName);
                 }
@@ -214,11 +73,25 @@ namespace Farmhand
             
             return null;
         }
-        
-        internal static Dictionary<string, AssemblyNameReference> xnaTypes = buildXnaTypeCache();
-        private static Dictionary<string, AssemblyNameReference> buildXnaTypeCache()
+
+        // This will return which assembly an XNA type is in. (See BuildXnaTypeCache())
+        internal static IMetadataScope FindXnaRef(TypeReference type)
         {
-            if (!WINDOWS) return new Dictionary<string, AssemblyNameReference>();
+            string key = type.Namespace + "." + type.Name;
+            if (!xnaTypes.ContainsKey(key))
+                return xnaRef;
+
+            return xnaTypes[key];
+        }
+
+        // Since Mono <-> (Xna,Graphics,Game), we can't just replace every Mono reference
+        // with XNA directly. So this will be the cache of which types go to which assembly.
+        internal static Dictionary<string, AssemblyNameReference> xnaTypes = BuildXnaTypeCache();
+        private static Dictionary<string, AssemblyNameReference> BuildXnaTypeCache()
+        {
+            // All XNA is replaced with the single Mono assembly on Linux/Mac anyways, so this won't be used.
+            if (!WINDOWS)
+                return new Dictionary<string, AssemblyNameReference>();
 
             var core = ModuleDefinition.ReadModule(typeof(Microsoft.Xna.Framework.Vector2).Module.FullyQualifiedName);
             var game = ModuleDefinition.ReadModule(typeof(Microsoft.Xna.Framework.Game).Module.FullyQualifiedName);
@@ -227,6 +100,10 @@ namespace Farmhand
             var ret = new Dictionary<string, AssemblyNameReference>();
             foreach (TypeDefinition type in core.GetTypes())
             {
+                // If they aren't public then nobody should be referencing them, so
+                // we don't need to fix any of those references.
+                // I can't remember why the '<' check was needed. I think compiler
+                // generated stuff caused duplicate key problems?
                 if (!type.IsPublic || type.Namespace.IndexOf("<") != -1) continue;
                 ret.Add(type.Namespace + "." + type.Name, xnaRef);
             }
@@ -245,72 +122,176 @@ namespace Farmhand
         }
     }
 
-    internal class ReferenceFixDefinition
+    // Fix references to other things. The ones we fix are the external references,
+    // but everything still needs to be checked, even if the top-level is fine.
+    // Stupid generics.
+    internal class Reference
     {
-        internal static void fix( AssemblyDefinition def )
+        private static FieldInfo typeRefField = typeof(TypeSpecification).GetField("scope", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo typeSpecField = typeof(TypeSpecification).GetField("element_type", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static TypeReference Fix(ModuleDefinition def, TypeReference type)
         {
-            Logging.Log.Verbose("FIXING " + def);
-            foreach ( ModuleDefinition mod in def.Modules )
+            string from = type.Scope.Name;
+
+            TypeReference ret = type;
+            if (ret.GetType() == typeof(TypeReference))
+            {
+                if (IsStardew(from))
+                    ret = new TypeReference(type.Namespace, type.Name, null, thisRef);
+                else if (!WINDOWS && IsXna(from))
+                    ret = new TypeReference(type.Namespace, type.Name, null, monoRef);
+                else if (WINDOWS && IsMono(from))
+                    ret = new TypeReference(type.Namespace, type.Name, null, FindXnaRef(type));
+                ret.IsValueType = type.IsValueType;
+            }
+            else if (ret.GetType() == typeof(GenericParameter))
+                return Fix(def, ret.DeclaringType, ret as GenericParameter);
+            else if (ret is TypeSpecification)
+                typeSpecField.SetValue(type, Fix(def, (type as TypeSpecification).ElementType));
+            else if (!(ret is TypeDefinition)) // Meaning it is defined in this assembly. I think?
+                Logging.Log.Warning("DON'T KNOW HOW TO DEAL WITH " + ret.GetType() + " " + ret);
+
+            if (type is GenericInstanceType)
+            {
+                for (int i = 0; i < (type as GenericInstanceType).ElementType.GenericParameters.Count; ++i)
+                {
+                    var t = (type as GenericInstanceType).ElementType.GenericParameters[i];
+                    (type as GenericInstanceType).ElementType.GenericParameters[i] = Fix(def, type, t);
+                }
+                for (int i = 0; i < (type as GenericInstanceType).GenericArguments.Count; ++i)
+                {
+                    var t = (type as GenericInstanceType).GenericArguments[i];
+                    (type as GenericInstanceType).GenericArguments[i] = Fix(def, t);
+                }
+            }
+            else if (type.HasGenericParameters)
+            {
+                for (int i = 0; i < type.GenericParameters.Count; ++i)
+                    type.GenericParameters[i] = Fix(def, type, type.GenericParameters[i]);
+            }
+
+            return def.Import(ret);
+        }
+
+        private static FieldInfo methSpecField = typeof(MethodSpecification).GetField("method", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static MethodReference Fix(ModuleDefinition def, MethodReference meth)
+        {
+            foreach (var param in meth.Parameters)
+                param.ParameterType = Fix(def, param.ParameterType);
+
+            if (meth is GenericInstanceMethod)
+            {
+                var gim = (meth as GenericInstanceMethod);
+                methSpecField.SetValue(meth, Fix(def, gim.ElementMethod));
+                for (int i = 0; i < gim.GenericParameters.Count; ++i)
+                    gim.GenericParameters[i] = Fix(def, meth, gim.GenericParameters[i]);
+                for (int i = 0; i < gim.GenericArguments.Count; ++i)
+                {
+                    gim.GenericArguments[i] = Fix(def, gim.GenericArguments[i]);
+                }
+            }
+            else if (meth.HasGenericParameters)
+            {
+                for (int i = 0; i < meth.GenericParameters.Count; ++i)
+                    meth.GenericParameters[i] = Fix(def, meth, meth.GenericParameters[i]);
+            }
+
+            meth.ReturnType = Fix(def, meth.ReturnType);
+            if (meth is MethodSpecification)
+            {
+                MethodReference elem = (methSpecField.GetValue(meth) as MethodReference);
+                methSpecField.SetValue(meth, Fix(def, elem));
+            }
+            else
+                meth.DeclaringType = Fix(def, meth.DeclaringType);
+            return def.Import(meth);
+        }
+
+        internal static FieldReference Fix(ModuleDefinition def, FieldReference field)
+        {
+            field.DeclaringType = Fix(def, field.DeclaringType);
+            field.FieldType = Fix(def, field.FieldType);
+            return def.Import(field);
+        }
+
+        private static FieldInfo genDeclOwner = typeof(GenericParameter).GetField("owner", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static GenericParameter Fix(ModuleDefinition def, IGenericParameterProvider parent, GenericParameter param)
+        {
+            for (int i = 0; i < param.Constraints.Count; ++i)
+                param.Constraints[i] = Fix(def, param.Constraints[i]);
+            for (int i = 0; i < param.GenericParameters.Count; ++i)
+                param.GenericParameters[i] = Fix(def, param, param.GenericParameters[i]);
+            return param;
+        }
+    }
+
+    // Fix the actual definitions of things, mainly to go down and find all
+    // of the references that need fixing.
+    internal class Definition
+    {
+        internal static void Fix(AssemblyDefinition def)
+        {
+            foreach (ModuleDefinition mod in def.Modules)
             {
                 foreach (var obj in mod.GetTypes())
-                    fix(obj);
+                    Fix(obj);
 
                 TypeReference[] refs = (TypeReference[])mod.GetTypeReferences();
                 for (int i = 0; i < refs.Count(); ++i)
                 {
-                    if (!ReferenceFixData.matchesPlatform(refs[i]))
-                        refs[i] = ReferenceFixData.fixType(mod,refs[i]);
+                    if (!MatchesPlatform(refs[i]))
+                        refs[i] = Reference.Fix(mod,refs[i]);
                 }
             }
         }
 
-        private static void fix( TypeDefinition type )
+        private static void Fix(TypeDefinition type)
         {
             if (type.BaseType != null)
-                type.BaseType = ReferenceFixData.fixType(type.Module, type.BaseType);
+                type.BaseType = Reference.Fix(type.Module, type.BaseType);
             for (int i = 0; i < type.Interfaces.Count; ++i)
-                type.Interfaces[i] = ReferenceFixData.fixType(type.Module, type.Interfaces[i]);
+                type.Interfaces[i] = Reference.Fix(type.Module, type.Interfaces[i]);
             foreach (var obj in type.Events)
             {
                 if (obj.AddMethod != null)
-                    fix(obj.AddMethod);
+                    Fix(obj.AddMethod);
                 if (obj.InvokeMethod != null)
-                    fix(obj.InvokeMethod);
+                    Fix(obj.InvokeMethod);
                 if (obj.RemoveMethod != null)
-                    fix(obj.RemoveMethod);
+                    Fix(obj.RemoveMethod);
                 foreach (var evMeth in obj.OtherMethods)
-                    fix(evMeth);
-                obj.EventType = ReferenceFixData.fixType(type.Module, obj.EventType);
+                    Fix(evMeth);
+                obj.EventType = Reference.Fix(type.Module, obj.EventType);
             }
             for (int i = 0; i < type.GenericParameters.Count; ++i)
-                type.GenericParameters[i] = ReferenceFixData.fixGeneric(type.Module, type, type.GenericParameters[i]);
+                type.GenericParameters[i] = Reference.Fix(type.Module, type, type.GenericParameters[i]);
             foreach (var obj in type.NestedTypes)
-                fix(obj);
+                Fix(obj);
             foreach (var obj in type.Methods)
-                fix(obj);
+                Fix(obj);
             foreach (var obj in type.Fields)
-                fix(obj);
+                Fix(obj);
         }
 
-        private static void fix(MethodDefinition meth)
+        private static void Fix(MethodDefinition meth)
         {
             foreach (var obj in meth.Parameters)
-                if(!ReferenceFixData.matchesPlatform(obj.ParameterType))
-                    obj.ParameterType = ReferenceFixData.fixType(meth.Module, obj.ParameterType);
-            if (!ReferenceFixData.matchesPlatform(meth.MethodReturnType.ReturnType))
-                meth.MethodReturnType.ReturnType = ReferenceFixData.fixType(meth.Module, meth.MethodReturnType.ReturnType);
+                if(!MatchesPlatform(obj.ParameterType))
+                    obj.ParameterType = Reference.Fix(meth.Module, obj.ParameterType);
+            if (!MatchesPlatform(meth.MethodReturnType.ReturnType))
+                meth.MethodReturnType.ReturnType = Reference.Fix(meth.Module, meth.MethodReturnType.ReturnType);
             for (int i = 0; i < meth.Overrides.Count; ++i)
-                meth.Overrides[i] = ReferenceFixData.fixMethod(meth.Module, meth.Overrides[i]);
+                meth.Overrides[i] = Reference.Fix(meth.Module, meth.Overrides[i]);
             
             if (meth.HasBody && meth.Body != null)
             {
-                if (meth.Body.ThisParameter != null && !ReferenceFixData.matchesPlatform(meth.Body.ThisParameter.ParameterType))
-                    meth.Body.ThisParameter.ParameterType = ReferenceFixData.fixType(meth.Module, meth.Body.ThisParameter.ParameterType);
+                if (meth.Body.ThisParameter != null && !MatchesPlatform(meth.Body.ThisParameter.ParameterType))
+                    meth.Body.ThisParameter.ParameterType = Reference.Fix(meth.Module, meth.Body.ThisParameter.ParameterType);
 
                 if (meth.Body.HasVariables)
                 {
                     foreach (var v in meth.Body.Variables)
-                        v.VariableType = ReferenceFixData.fixType(meth.Module, v.VariableType);
+                        v.VariableType = Reference.Fix(meth.Module, v.VariableType);
                 }
 
                 foreach (Instruction insn in meth.Body.Instructions)
@@ -323,29 +304,29 @@ namespace Farmhand
                     var asParam = oper as ParameterDefinition;
                     var asCall = oper as CallSite;
                     if (asType != null)
-                        insn.Operand = ReferenceFixData.fixType(meth.Module, asType);
+                        insn.Operand = Reference.Fix(meth.Module, asType);
                     else if (asMeth != null)
-                        insn.Operand = ReferenceFixData.fixMethod(meth.Module, asMeth);
+                        insn.Operand = Reference.Fix(meth.Module, asMeth);
                     else if (asField != null)
-                        insn.Operand = ReferenceFixData.fixField(meth.Module, asField);
+                        insn.Operand = Reference.Fix(meth.Module, asField);
                     else if (asVar != null)
-                        asVar.VariableType = ReferenceFixData.fixType(meth.Module, asVar.VariableType);
+                        asVar.VariableType = Reference.Fix(meth.Module, asVar.VariableType);
                     else if (asParam != null)
-                        asParam.ParameterType = ReferenceFixData.fixType(meth.Module, asParam.ParameterType);
+                        asParam.ParameterType = Reference.Fix(meth.Module, asParam.ParameterType);
                     else if (asCall != null)
                     {
                         foreach (var param in asCall.Parameters)
-                            param.ParameterType = ReferenceFixData.fixType(meth.Module, param.ParameterType);
-                        asCall.ReturnType = ReferenceFixData.fixType(meth.Module, asCall.ReturnType);
+                            param.ParameterType = Reference.Fix(meth.Module, param.ParameterType);
+                        asCall.ReturnType = Reference.Fix(meth.Module, asCall.ReturnType);
                     }
                 }
             }
         }
 
-        private static void fix(FieldDefinition field)
+        private static void Fix(FieldDefinition field)
         {
-            if (!ReferenceFixData.matchesPlatform(field.FieldType))
-                field.FieldType = ReferenceFixData.fixType(field.Module, field.FieldType);
+            if (!MatchesPlatform(field.FieldType))
+                field.FieldType = Reference.Fix(field.Module, field.FieldType);
         }
     }
 }

--- a/Libraries/Farmhand/Mods/ReferenceFix.cs
+++ b/Libraries/Farmhand/Mods/ReferenceFix.cs
@@ -109,9 +109,14 @@ namespace Farmhand
 
             if (meth is GenericInstanceMethod)
             {
-                methSpecField.SetValue(meth, fixMethod(def, (meth as GenericInstanceMethod).ElementMethod));
-                for (int i = 0; i < (meth as GenericInstanceMethod).GenericParameters.Count; ++i)
-                    meth.GenericParameters[i] = fixGeneric(def, meth, meth.GenericParameters[i]);
+                var gim = (meth as GenericInstanceMethod);
+                methSpecField.SetValue(meth, fixMethod(def, gim.ElementMethod));
+                for (int i = 0; i < gim.GenericParameters.Count; ++i)
+                    gim.GenericParameters[i] = fixGeneric(def, meth, gim.GenericParameters[i]);
+                for (int i = 0; i < gim.GenericArguments.Count; ++i)
+                {
+                    gim.GenericArguments[i] = fixType(def, gim.GenericArguments[i]);
+                }
             }
             else if (meth.HasGenericParameters)
             {
@@ -122,7 +127,8 @@ namespace Farmhand
             meth.ReturnType = fixType(def, meth.ReturnType);
             if (meth is MethodSpecification)
             {
-                (methSpecField.GetValue(meth) as MethodReference).DeclaringType = fixType(def, meth.DeclaringType);
+                MethodReference elem = (methSpecField.GetValue(meth) as MethodReference);
+                methSpecField.SetValue(meth, fixMethod(def, elem));
             }
             else
                 meth.DeclaringType = fixType(def, meth.DeclaringType);

--- a/Libraries/Farmhand/Mods/ReferenceFix.cs
+++ b/Libraries/Farmhand/Mods/ReferenceFix.cs
@@ -1,0 +1,345 @@
+﻿using Mono.Cecil;
+using Mono.Cecil.Cil;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+// Since WINDOWS is hardcoded to true right now, this is necessary to prevent
+// "unreachable code detected" from keeping the thing from compiling.
+#pragma warning disable 0162
+
+namespace Farmhand
+{
+    internal static class ReferenceFixData
+    {
+        internal const bool WINDOWS = true;
+
+        internal static AssemblyNameReference fixRef(string @ref) { return fixRef(AssemblyNameReference.Parse(@ref)); }
+        internal static AssemblyNameReference fixRef(AssemblyNameReference @ref)
+        {
+            if (isStardew(@ref))
+                return thisRef;
+
+            if (!WINDOWS && isXna(@ref))
+            {
+                return monoRef;
+            }
+            else if (WINDOWS && isMono(@ref))
+            {
+                // Okay, I really have no clue what to do here, since the mapping for mono/xna is
+                // MonoGame.Framework <=> Microsoft.Xna.Framework(|.Game|.Graphics)
+                // I'm hoping the metadata resolver will help with this
+                return xnaRef;
+            }
+
+            return @ref;
+        }
+
+        // If referencing vanilla Stardew, it wasn't built for Farmhand.
+        // If on Windows and referencing Mono, it won't be compatible.
+        // If not on Windows and referencing Microsoft XNA, it won't be compatible.
+        // If none of these are true, everything is fine.
+        internal static bool matchesPlatform(AssemblyNameReference asmRef)
+        {
+            return !(isStardew(asmRef) ||
+                     WINDOWS && isMono(asmRef) ||
+                     !WINDOWS && isXna(asmRef));
+        }
+
+        internal static bool matchesPlatform(TypeReference asmRef)
+        {
+            return (isStardew(asmRef.Namespace) ||
+                    WINDOWS && isMono(asmRef.Namespace) ||
+                    !WINDOWS && isXna(asmRef.Namespace));
+        }
+
+        private static FieldInfo typeRefField = typeof(TypeSpecification).GetField("scope", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo typeSpecField = typeof(TypeSpecification).GetField("element_type", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static TypeReference fixType(ModuleDefinition def, TypeReference type)
+        {
+            string from = type.Scope.Name;
+
+            TypeReference ret = type;
+            if (ret.GetType() == typeof(TypeReference))
+            {
+                if (isStardew(from))
+                    ret = new TypeReference(type.Namespace, type.Name, null, thisRef);
+                else if (!WINDOWS && isXna(from))
+                    ret = new TypeReference(type.Namespace, type.Name, null, monoRef);
+                else if (WINDOWS && isMono(from))
+                    ret = new TypeReference(type.Namespace, type.Name, null, findXnaRef(type));
+                ret.IsValueType = type.IsValueType;
+            }
+            else if (ret.GetType() == typeof(GenericParameter))
+                return fixGeneric(def, ret.DeclaringType, ret as GenericParameter);
+            else if (ret is TypeSpecification)
+                typeSpecField.SetValue(type, fixType(def, (type as TypeSpecification).ElementType));
+            else if (!(ret is TypeDefinition)) // Meaning it is defined in this assembly. I think?
+                Logging.Log.Warning("DON'T KNOW HOW TO DEAL WITH " + ret.GetType() + " " + ret);
+
+            if (type is GenericInstanceType)
+            {
+                for (int i = 0; i < (type as GenericInstanceType).ElementType.GenericParameters.Count; ++i)
+                {
+                    var t = (type as GenericInstanceType).ElementType.GenericParameters[i];
+                    (type as GenericInstanceType).ElementType.GenericParameters[i] = fixGeneric(def, type, t);
+                }
+                for (int i = 0; i < (type as GenericInstanceType).GenericArguments.Count; ++i)
+                {
+                    var t = (type as GenericInstanceType).GenericArguments[i];
+                    (type as GenericInstanceType).GenericArguments[i] = fixType(def, t);
+                }
+            }
+            else if ( type.HasGenericParameters )
+            {
+                for (int i = 0; i < type.GenericParameters.Count; ++i)
+                    type.GenericParameters[i] = fixGeneric(def, type, type.GenericParameters[i]);
+            }
+
+            return def.Import( ret );
+        }
+
+        private static FieldInfo methSpecField = typeof(MethodSpecification).GetField("method", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static MethodReference fixMethod(ModuleDefinition def, MethodReference meth)
+        {
+            foreach (var param in meth.Parameters)
+                param.ParameterType = fixType(def, param.ParameterType);
+
+            if (meth is GenericInstanceMethod)
+            {
+                methSpecField.SetValue(meth, fixMethod(def, (meth as GenericInstanceMethod).ElementMethod));
+                for (int i = 0; i < (meth as GenericInstanceMethod).GenericParameters.Count; ++i)
+                    meth.GenericParameters[i] = fixGeneric(def, meth, meth.GenericParameters[i]);
+            }
+            else if (meth.HasGenericParameters)
+            {
+                for (int i = 0; i < meth.GenericParameters.Count; ++i)
+                    meth.GenericParameters[i] = fixGeneric(def, meth, meth.GenericParameters[i]);
+            }
+            
+            meth.ReturnType = fixType(def, meth.ReturnType);
+            if (meth is MethodSpecification)
+            {
+                (methSpecField.GetValue(meth) as MethodReference).DeclaringType = fixType(def, meth.DeclaringType);
+            }
+            else
+                meth.DeclaringType = fixType(def, meth.DeclaringType);
+            return def.Import(meth);
+        }
+
+        internal static FieldReference fixField(ModuleDefinition def, FieldReference field)
+        {
+            field.DeclaringType = fixType(def, field.DeclaringType);
+            field.FieldType = fixType(def, field.FieldType);
+            return def.Import(field);
+        }
+
+        private static FieldInfo genDeclOwner = typeof(GenericParameter).GetField("owner", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static GenericParameter fixGeneric( ModuleDefinition def, IGenericParameterProvider parent, GenericParameter param )
+        {
+            for (int i = 0; i < param.Constraints.Count; ++i)
+                param.Constraints[i] = fixType(def, param.Constraints[i]);
+            for (int i = 0; i < param.GenericParameters.Count; ++i)
+                param.GenericParameters[i] = fixGeneric(def, param, param.GenericParameters[i]);
+            /*
+            if (param.DeclaringType != null)
+                genDeclOwner.SetValue(param, fixType(def, param.DeclaringType));
+            else if (param.DeclaringMethod != null)
+                genDeclOwner.SetValue(param, fixMethod(def, param.DeclaringMethod));
+            //*/
+            return param;
+        }
+
+        private static IMetadataScope findXnaRef(TypeReference type)
+        {
+            string key = type.Namespace + "." + type.Name;
+            if (!xnaTypes.ContainsKey(key))
+                return xnaRef;
+                //Logging.Log.Error("NO XNA KEY " + key + " " + type + " " + type.Scope + " " + type.DeclaringType + " " + Environment.StackTrace);
+
+            return xnaTypes[ key ];
+        }
+
+        internal static bool isStardew(string @ref)
+        {
+           return @ref.StartsWith( "Stardew Valley" ) || @ref.StartsWith( "StardewValley" );
+        }
+        internal static bool isStardew(AssemblyNameReference @ref)
+        {
+            return @ref.Name == "Stardew Valley" || @ref.Name == "StardewValley";
+        }
+
+        // Can't compare to static vars because they are null for the opposite platform
+        internal static bool isXna(string @ref)
+        {
+            return @ref.StartsWith("Microsoft.Xna.Framework");
+        }
+        internal static bool isXna( AssemblyNameReference @ref )
+        {
+            return @ref.Name == "Microsoft.Xna.Framework" || @ref.Name == "Microsoft.Xna.Framework.Game" || @ref.Name == "Microsoft.Xna.Framework.Graphics";
+        }
+
+        internal static bool isMono(string @ref)
+        {
+            return @ref.StartsWith("MonoGame.Framework");
+        }
+        internal static bool isMono( AssemblyNameReference @ref )
+        {
+            return @ref.Name == "MonoGame.Framework";
+        }
+
+        internal static AssemblyNameReference thisRef = AssemblyNameReference.Parse(Assembly.GetExecutingAssembly().FullName);
+        internal static AssemblyNameReference monoRef = findMyRef("MonoGame.Framework");
+        internal static AssemblyNameReference xnaRef = findMyRef("Microsoft.Xna.Framework");
+        internal static AssemblyNameReference xnaGameRef = findMyRef("Microsoft.Xna.Framework.Game");
+        internal static AssemblyNameReference xnaGraphicsRef = findMyRef("Microsoft.Xna.Framework.Graphics");
+
+        internal static AssemblyNameReference findMyRef( string name )
+        {
+            foreach ( var @ref in Assembly.GetExecutingAssembly().GetReferencedAssemblies() )
+            {
+                if ( @ref.Name == name )
+                {
+                    return AssemblyNameReference.Parse(@ref.FullName);
+                }
+            }
+            
+            return null;
+        }
+        
+        internal static Dictionary<string, AssemblyNameReference> xnaTypes = buildXnaTypeCache();
+        private static Dictionary<string, AssemblyNameReference> buildXnaTypeCache()
+        {
+            if (!WINDOWS) return new Dictionary<string, AssemblyNameReference>();
+
+            var core = ModuleDefinition.ReadModule(typeof(Microsoft.Xna.Framework.Vector2).Module.FullyQualifiedName);
+            var game = ModuleDefinition.ReadModule(typeof(Microsoft.Xna.Framework.Game).Module.FullyQualifiedName);
+            var graphics = ModuleDefinition.ReadModule(typeof(Microsoft.Xna.Framework.Graphics.SpriteBatch).Module.FullyQualifiedName);
+
+            var ret = new Dictionary<string, AssemblyNameReference>();
+            foreach (TypeDefinition type in core.GetTypes())
+            {
+                if (!type.IsPublic || type.Namespace.IndexOf("<") != -1) continue;
+                ret.Add(type.Namespace + "." + type.Name, xnaRef);
+            }
+            foreach (TypeDefinition type in game.GetTypes())
+            {
+                if (!type.IsPublic || type.Namespace.IndexOf("<") != -1) continue;
+                ret.Add(type.Namespace + "." + type.Name, xnaGameRef);
+            }
+            foreach (TypeDefinition type in graphics.GetTypes())
+            {
+                if (!type.IsPublic || type.Namespace.IndexOf("<") != -1) continue;
+                ret.Add(type.Namespace + "." + type.Name, xnaGraphicsRef);
+            }
+
+            return ret;
+        }
+    }
+
+    internal class ReferenceFixDefinition
+    {
+        internal static void fix( AssemblyDefinition def )
+        {
+            Logging.Log.Verbose("FIXING " + def);
+            foreach ( ModuleDefinition mod in def.Modules )
+            {
+                foreach (var obj in mod.GetTypes())
+                    fix(obj);
+
+                TypeReference[] refs = (TypeReference[])mod.GetTypeReferences();
+                for (int i = 0; i < refs.Count(); ++i)
+                {
+                    if (!ReferenceFixData.matchesPlatform(refs[i]))
+                        refs[i] = ReferenceFixData.fixType(mod,refs[i]);
+                }
+            }
+        }
+
+        private static void fix( TypeDefinition type )
+        {
+            if (type.BaseType != null)
+                type.BaseType = ReferenceFixData.fixType(type.Module, type.BaseType);
+            for (int i = 0; i < type.Interfaces.Count; ++i)
+                type.Interfaces[i] = ReferenceFixData.fixType(type.Module, type.Interfaces[i]);
+            foreach (var obj in type.Events)
+            {
+                if (obj.AddMethod != null)
+                    fix(obj.AddMethod);
+                if (obj.InvokeMethod != null)
+                    fix(obj.InvokeMethod);
+                if (obj.RemoveMethod != null)
+                    fix(obj.RemoveMethod);
+                foreach (var evMeth in obj.OtherMethods)
+                    fix(evMeth);
+                obj.EventType = ReferenceFixData.fixType(type.Module, obj.EventType);
+            }
+            for (int i = 0; i < type.GenericParameters.Count; ++i)
+                type.GenericParameters[i] = ReferenceFixData.fixGeneric(type.Module, type, type.GenericParameters[i]);
+            foreach (var obj in type.NestedTypes)
+                fix(obj);
+            foreach (var obj in type.Methods)
+                fix(obj);
+            foreach (var obj in type.Fields)
+                fix(obj);
+        }
+
+        private static void fix(MethodDefinition meth)
+        {
+            foreach (var obj in meth.Parameters)
+                if(!ReferenceFixData.matchesPlatform(obj.ParameterType))
+                    obj.ParameterType = ReferenceFixData.fixType(meth.Module, obj.ParameterType);
+            if (!ReferenceFixData.matchesPlatform(meth.MethodReturnType.ReturnType))
+                meth.MethodReturnType.ReturnType = ReferenceFixData.fixType(meth.Module, meth.MethodReturnType.ReturnType);
+            for (int i = 0; i < meth.Overrides.Count; ++i)
+                meth.Overrides[i] = ReferenceFixData.fixMethod(meth.Module, meth.Overrides[i]);
+            
+            if (meth.HasBody && meth.Body != null)
+            {
+                if (meth.Body.ThisParameter != null && !ReferenceFixData.matchesPlatform(meth.Body.ThisParameter.ParameterType))
+                    meth.Body.ThisParameter.ParameterType = ReferenceFixData.fixType(meth.Module, meth.Body.ThisParameter.ParameterType);
+
+                if (meth.Body.HasVariables)
+                {
+                    foreach (var v in meth.Body.Variables)
+                        v.VariableType = ReferenceFixData.fixType(meth.Module, v.VariableType);
+                }
+
+                foreach (Instruction insn in meth.Body.Instructions)
+                {
+                    object oper = insn.Operand;
+                    var asType = oper as TypeReference;
+                    var asMeth = oper as MethodReference;
+                    var asField = oper as FieldReference;
+                    var asVar = oper as VariableDefinition;
+                    var asParam = oper as ParameterDefinition;
+                    var asCall = oper as CallSite;
+                    if (asType != null)
+                        insn.Operand = ReferenceFixData.fixType(meth.Module, asType);
+                    else if (asMeth != null)
+                        insn.Operand = ReferenceFixData.fixMethod(meth.Module, asMeth);
+                    else if (asField != null)
+                        insn.Operand = ReferenceFixData.fixField(meth.Module, asField);
+                    else if (asVar != null)
+                        asVar.VariableType = ReferenceFixData.fixType(meth.Module, asVar.VariableType);
+                    else if (asParam != null)
+                        asParam.ParameterType = ReferenceFixData.fixType(meth.Module, asParam.ParameterType);
+                    else if (asCall != null)
+                    {
+                        foreach (var param in asCall.Parameters)
+                            param.ParameterType = ReferenceFixData.fixType(meth.Module, param.ParameterType);
+                        asCall.ReturnType = ReferenceFixData.fixType(meth.Module, asCall.ReturnType);
+                    }
+                }
+            }
+        }
+
+        private static void fix(FieldDefinition field)
+        {
+            if (!ReferenceFixData.matchesPlatform(field.FieldType))
+                field.FieldType = ReferenceFixData.fixType(field.Module, field.FieldType);
+        }
+    }
+}

--- a/Libraries/Farmhand/Registries/Containers/ModManifest.cs
+++ b/Libraries/Farmhand/Registries/Containers/ModManifest.cs
@@ -136,7 +136,7 @@ namespace Farmhand.Registries.Containers
                     // ourself SEEMS to fix that.
                     int index = asm.MainModule.AssemblyReferences.IndexOf(@ref);
                     asm.MainModule.AssemblyReferences.Remove(@ref);
-                    asm.MainModule.AssemblyReferences.Insert(index, ReferenceFixData.xnaRef);
+                    asm.MainModule.AssemblyReferences.Insert(index, ReferenceFixData.thisRef);
                 }
                 if ( shouldFix )
                 {

--- a/Libraries/Farmhand/Registries/Containers/ModManifest.cs
+++ b/Libraries/Farmhand/Registries/Containers/ModManifest.cs
@@ -114,7 +114,8 @@ namespace Farmhand.Registries.Containers
                 // (Trust me, I tried. Suddenly it looks for the definition of
                 // Vector2 inside the Farmhand assembly, or somewhere else
                 // bizarre.)
-                var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly(modDllPath);
+                byte[] bytes = System.IO.File.ReadAllBytes(modDllPath);
+                var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly(new System.IO.MemoryStream(bytes, false));
                 bool shouldFix = false;
                 var toRemove = new List<AssemblyNameReference>();
                 foreach (var asmRef in asm.MainModule.AssemblyReferences)
@@ -141,14 +142,12 @@ namespace Farmhand.Registries.Containers
                 if ( shouldFix )
                 {
                     ReferenceFixDefinition.fix(asm);
-                }
-
-                byte[] bytes = null;
-                using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
-                {
-                    asm.Write(stream);
-                    bytes = stream.GetBuffer();
-                    //System.IO.File.WriteAllBytes(modDllPath + "-edited.dll", bytes);
+                    using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
+                    {
+                        asm.Write(stream);
+                        bytes = stream.GetBuffer();
+                        //System.IO.File.WriteAllBytes(modDllPath + "-edited.dll", bytes);
+                    }
                 }
 
                 ModAssembly = Assembly.Load(bytes);

--- a/Libraries/Farmhand/Registries/Containers/ModManifest.cs
+++ b/Libraries/Farmhand/Registries/Containers/ModManifest.cs
@@ -174,7 +174,7 @@ namespace Farmhand.Registries.Containers
                 // We only want to go to the effort of fixing everything if 
                 // there is a reference that even needs fixing.
                 // Also, the bad references will need to be removed.
-                if (!ReferenceFixData.matchesPlatform(asmRef))
+                if (!ReferenceFix.Data.MatchesPlatform(asmRef))
                 {
                     shouldFix = true;
                     toRemove.Add(asmRef);
@@ -188,7 +188,7 @@ namespace Farmhand.Registries.Containers
                 // ourself SEEMS to fix that.
                 int index = asm.MainModule.AssemblyReferences.IndexOf(@ref);
                 asm.MainModule.AssemblyReferences.Remove(@ref);
-                asm.MainModule.AssemblyReferences.Insert(index, ReferenceFixData.thisRef);
+                asm.MainModule.AssemblyReferences.Insert(index, ReferenceFix.Data.thisRef);
             }
 
             if (shouldFix)
@@ -224,7 +224,7 @@ namespace Farmhand.Registries.Containers
 
         private byte[] fixDll( Mono.Cecil.AssemblyDefinition asm, string cachePath )
         {
-            ReferenceFixDefinition.fix(asm);
+            ReferenceFix.Definition.Fix(asm);
 
             byte[] bytes = null;
             using (MemoryStream stream = new MemoryStream())

--- a/Libraries/Farmhand/Registries/Containers/ModManifest.cs
+++ b/Libraries/Farmhand/Registries/Containers/ModManifest.cs
@@ -97,81 +97,9 @@ namespace Farmhand.Registries.Containers
                 throw new Exception("Error! Mod has already been loaded!");
             }
 
-            var modDllPath = $"{ModDirectory}\\{ModDll}";
-
-            if (!modDllPath.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase))
-            {
-                modDllPath += ".dll";
-            }
-
             try
             {
-                // When a SMAPI mod is still referencing the vanilla assembly,
-                // it doesn't see the Farmhand game. Everything will still be 
-                // in the state for when the assembly would first be loaded.
-                // This will fix the references so the mods will actually work.
-                //
-                // For loading mods from other platforms:
-                // There are also problems with XNA <=> Mono. Simply replacing
-                // the assembly name isn't really possible in this case, since
-                // all three XNA assemblies map to one Mono framework.
-                // (Trust me, I tried. Suddenly it looks for the definition of
-                // Vector2 inside the Farmhand assembly, or somewhere else
-                // bizarre.)
-                byte[] bytes = System.IO.File.ReadAllBytes(modDllPath);
-                var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly(new System.IO.MemoryStream(bytes, false));
-                bool shouldFix = false;
-                var toRemove = new List<AssemblyNameReference>();
-                foreach (var asmRef in asm.MainModule.AssemblyReferences)
-                {
-                    // We only want to go to the effort of fixing everything if 
-                    // there is a reference that even needs fixing.
-                    // Also, the bad references will need to be removed.
-                    if (!ReferenceFixData.matchesPlatform(asmRef))
-                    {
-                        shouldFix = true;
-                        toRemove.Add(asmRef);
-                    }
-                }
-                foreach (var @ref in toRemove)
-                {
-                    // However, we can't just simply remove the old references.
-                    // The indices mess up and really weird stuff happens (see
-                    // two comment blocks ago). Placing a dummy re-reference of
-                    // ourself SEEMS to fix that.
-                    int index = asm.MainModule.AssemblyReferences.IndexOf(@ref);
-                    asm.MainModule.AssemblyReferences.Remove(@ref);
-                    asm.MainModule.AssemblyReferences.Insert(index, ReferenceFixData.thisRef);
-                }
-                if ( shouldFix )
-                {
-                    if (Program.Config.CachePorts)
-                    {
-                        // We want to cache any 'fixed' assemblies so that we don't have to
-                        // go through and fix everything again. However if the mod is updated
-                        // or something, it will need to be fixed again.
-                        string check = Convert.ToBase64String(sha1.ComputeHash(bytes));
-                        check = check.Replace("=", "").Replace('+', '-').Replace('/', '_'); // Fix for valid file name. = is just padding
-                        string checkPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                                                        "StardewValley", "cache", ModDll + "-" + check + ".dll");
-                        if (File.Exists(checkPath))
-                        {
-                            try
-                            {
-                                bytes = File.ReadAllBytes(checkPath);
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Exception($"Exception reading cached DLL {checkPath}", ex);
-                                bytes = fixDll(asm, checkPath);
-                            }
-                        }
-                        else bytes = fixDll(asm, checkPath);
-                    }
-                    else bytes = fixDll(asm, null);
-                }
-
-                ModAssembly = Assembly.Load(bytes);
+                ModAssembly = Assembly.Load(getDllBytes());
                 if (ModAssembly.GetTypes().Count(x => x.BaseType == typeof(Farmhand.Mod)) > 0)
                 {
                     var type = ModAssembly.GetTypes().First(x => x.BaseType == typeof(Farmhand.Mod));
@@ -214,7 +142,87 @@ namespace Farmhand.Registries.Containers
             return Instance != null;
         }
 
-        internal byte[] fixDll( Mono.Cecil.AssemblyDefinition asm, string cachePath )
+        internal byte[] getDllBytes()
+        {
+            var modDllPath = $"{ModDirectory}\\{ModDll}";
+
+            if (!modDllPath.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase))
+            {
+                modDllPath += ".dll";
+            }
+
+            // When a SMAPI mod is still referencing the vanilla assembly,
+            // it doesn't see the Farmhand game. Everything will still be 
+            // in the state for when the assembly would first be loaded.
+            // This will fix the references so the mods will actually work.
+            //
+            // For loading mods from other platforms:
+            // There are also problems with XNA <=> Mono. Simply replacing
+            // the assembly name isn't really possible in this case, since
+            // all three XNA assemblies map to one Mono framework.
+            // (Trust me, I tried. Suddenly it looks for the definition of
+            // Vector2 inside the Farmhand assembly, or somewhere else
+            // bizarre.)
+            byte[] bytes = System.IO.File.ReadAllBytes(modDllPath);
+
+            var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly(new System.IO.MemoryStream(bytes, false));
+
+            bool shouldFix = false;
+            var toRemove = new List<AssemblyNameReference>();
+            foreach (var asmRef in asm.MainModule.AssemblyReferences)
+            {
+                // We only want to go to the effort of fixing everything if 
+                // there is a reference that even needs fixing.
+                // Also, the bad references will need to be removed.
+                if (!ReferenceFixData.matchesPlatform(asmRef))
+                {
+                    shouldFix = true;
+                    toRemove.Add(asmRef);
+                }
+            }
+            foreach (var @ref in toRemove)
+            {
+                // However, we can't just simply remove the old references.
+                // The indices mess up and really weird stuff happens (see
+                // two comment blocks ago). Placing a dummy re-reference of
+                // ourself SEEMS to fix that.
+                int index = asm.MainModule.AssemblyReferences.IndexOf(@ref);
+                asm.MainModule.AssemblyReferences.Remove(@ref);
+                asm.MainModule.AssemblyReferences.Insert(index, ReferenceFixData.thisRef);
+            }
+
+            if (shouldFix)
+            {
+                if (Program.Config.CachePorts)
+                {
+                    // We want to cache any 'fixed' assemblies so that we don't have to
+                    // go through and fix everything again. However if the mod is updated
+                    // or something, it will need to be fixed again.
+                    string check = Convert.ToBase64String(sha1.ComputeHash(bytes));
+                    check = check.Replace("=", "").Replace('+', '-').Replace('/', '_'); // Fix for valid file name. = is just padding
+                    string checkPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                                                    "StardewValley", "cache", ModDll + "-" + check + ".dll");
+                    if (File.Exists(checkPath))
+                    {
+                        try
+                        {
+                            bytes = File.ReadAllBytes(checkPath);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Exception($"Exception reading cached DLL {checkPath}", ex);
+                            bytes = fixDll(asm, checkPath);
+                        }
+                    }
+                    else bytes = fixDll(asm, checkPath);
+                }
+                else bytes = fixDll(asm, null);
+            }
+
+            return bytes;
+        }
+
+        private byte[] fixDll( Mono.Cecil.AssemblyDefinition asm, string cachePath )
         {
             ReferenceFixDefinition.fix(asm);
 


### PR DESCRIPTION
This will allow linux/mac/mono mods to load on Windows/MicrosoftXNA (and in theory the other way around). The 'fixed' versions are cached in %APPDATA%\StardewValley\cache, so that fixing doesn't necessarily need to be done every time the game loads. This can disabled with a new config option.

Tested with ChestsAnywhere.