### PR TITLE
Added nested type support for hooks.

### DIFF
--- a/Installers/Patcher/FarmhandPatcherCommon/Cecil/CecilContext.cs
+++ b/Installers/Patcher/FarmhandPatcherCommon/Cecil/CecilContext.cs
@@ -55,7 +55,7 @@ namespace Farmhand.Cecil
             return ilProcessor;
         }
 
-        public TypeDefinition GetTypeDefinition(string type)
+        public TypeDefinition GetTypeDefinition(string type, Mono.Collections.Generic.Collection<TypeDefinition> toCheck = null)
         {
             if (AssemblyDefinition == null)
                 throw new Exception("ERROR Assembly not properly read. Cannot parse");
@@ -63,7 +63,25 @@ namespace Farmhand.Cecil
             if (string.IsNullOrWhiteSpace(type))
                 throw new Exception("Both type and method must be set");
             AssemblyDefinition.MainModule.Import(typeof(void));
-            TypeDefinition typeDef = AssemblyDefinition.MainModule.Types.FirstOrDefault(n => n.FullName == type);
+
+            if (toCheck == null)
+                toCheck = AssemblyDefinition.MainModule.Types;
+            TypeDefinition typeDef = default(TypeDefinition);
+            foreach (TypeDefinition def in toCheck)
+            {
+                if (def.FullName == type)
+                {
+                    typeDef = def;
+                    break;
+                }
+                else if (type.StartsWith(def.FullName) && def.HasNestedTypes)
+                {
+                    typeDef = GetTypeDefinition(type, def.NestedTypes);
+                    if (typeDef != null)
+                        break;
+                }
+            }
+
             return typeDef;
         }
         


### PR DESCRIPTION
Nested types use '/' instead of '.' as separators.
I tried forcing it to ignore the difference in that one function, but it affected other places using `TypeDefinition.FullName` as well.

So for example, instead of `[Hook(HookType.Entry, "StardewValley.Class.NestedClass", "Func")]`, it would be `[Hook(HookType.Entry, "StardewValley.Class/NestedClass", "Func")]`. (Or that was how it worked in my test case, which is actually a compiler-generated nested class.)