### PR TITLE
Allow patcher exceptions to let the patcher fail.

### DIFF
--- a/Installers/Patcher/FarmhandPatcherSecondPass/PatcherSecondPass.cs
+++ b/Installers/Patcher/FarmhandPatcherSecondPass/PatcherSecondPass.cs
@@ -96,6 +96,7 @@ namespace Farmhand
                     catch (Exception ex)
                     {
                         Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
+                        throw ex;
                     }
                 }
             }
@@ -139,6 +140,7 @@ namespace Farmhand
                     catch (Exception ex)
                     {
                         Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
+                        throw ex;
                     }
                 }
             }
@@ -211,6 +213,7 @@ namespace Farmhand
                     catch (Exception ex)
                     {
                         Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
+                        throw ex;
                     }
                 }
             }

--- a/Installers/Patcher/FarmhandPatcherSecondPass/PatcherSecondPass.cs
+++ b/Installers/Patcher/FarmhandPatcherSecondPass/PatcherSecondPass.cs
@@ -62,99 +62,85 @@ namespace Farmhand
 
         protected override void HookApiEvents(CecilContext cecilContext)
         {
-            try
+            var methods = FarmhandAssemblies.SelectMany(a => a.GetTypes())
+                        .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+                        .Where(m => m.GetCustomAttributes(typeof(HookAttribute), false).Any())
+                        .ToArray();
+
+            foreach (var method in methods)
             {
-                var methods = FarmhandAssemblies.SelectMany(a => a.GetTypes())
-                            .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
-                            .Where(m => m.GetCustomAttributes(typeof(HookAttribute), false).Any())
-                            .ToArray();
+                if (method.DeclaringType == null) continue;
 
-                foreach (var method in methods)
+                var typeName = method.DeclaringType.FullName;
+                var methodName = method.Name;
+                var hookAttributes = method.GetCustomAttributes(typeof(HookAttribute), false).Cast<HookAttribute>();
+
+                foreach (var hook in hookAttributes)
                 {
-                    if (method.DeclaringType == null) continue;
-
-                    var typeName = method.DeclaringType.FullName;
-                    var methodName = method.Name;
-                    var hookAttributes = method.GetCustomAttributes(typeof(HookAttribute), false).Cast<HookAttribute>();
-
-                    foreach (var hook in hookAttributes)
+                    var hookTypeName = hook.Type;
+                    var hookMethodName = hook.Method;
+                    try
                     {
-                        var hookTypeName = hook.Type;
-                        var hookMethodName = hook.Method;
-                        try
+                        switch (hook.HookType)
                         {
-                            switch (hook.HookType)
-                            {
-                                case HookType.Entry:
-                                    CecilHelper.InjectEntryMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute>
-                                        (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
-                                case HookType.Exit:
-                                    CecilHelper.InjectExitMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute>
-                        (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
-                                default:
-                                    throw new Exception("Unknown HookType");
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
+                            case HookType.Entry:
+                                CecilHelper.InjectEntryMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute>
+                                    (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
+                            case HookType.Exit:
+                                CecilHelper.InjectExitMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute>
+                    (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
+                            default:
+                                throw new Exception("Unknown HookType");
                         }
                     }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
             }
         }
 
         private void HookOutputableApiEvents(CecilContext cecilContext)
         {
-            try
+            var methods = FarmhandAssemblies.SelectMany(a => a.GetTypes())
+                        .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+                        .Where(m => m.GetCustomAttributes(typeof(HookReturnableAttribute), false).Any())
+                        .ToArray();
+
+            foreach (var method in methods)
             {
-                var methods = FarmhandAssemblies.SelectMany(a => a.GetTypes())
-                            .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
-                            .Where(m => m.GetCustomAttributes(typeof(HookReturnableAttribute), false).Any())
-                            .ToArray();
+                if (method.DeclaringType == null) continue;
 
-                foreach (var method in methods)
+                var typeName = method.DeclaringType.FullName;
+                var methodName = method.Name;
+                var hookAttributes = method.GetCustomAttributes(typeof(HookReturnableAttribute), false).Cast<HookReturnableAttribute>();
+
+                foreach (var hook in hookAttributes)
                 {
-                    if (method.DeclaringType == null) continue;
-
-                    var typeName = method.DeclaringType.FullName;
-                    var methodName = method.Name;
-                    var hookAttributes = method.GetCustomAttributes(typeof(HookReturnableAttribute), false).Cast<HookReturnableAttribute>();
-
-                    foreach (var hook in hookAttributes)
+                    var hookTypeName = hook.Type;
+                    var hookMethodName = hook.Method;
+                    try
                     {
-                        var hookTypeName = hook.Type;
-                        var hookMethodName = hook.Method;
-                        try
+                        switch (hook.HookType)
                         {
-                            switch (hook.HookType)
-                            {
-                                case HookType.Entry:
-                                    CecilHelper.InjectReturnableEntryMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute,
-                                        UseOutputBindAttribute, MethodOutputBindAttribute>
-                                        (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
-                                case HookType.Exit:
-                                    CecilHelper.InjectReturnableExitMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute,
-                                        UseOutputBindAttribute, MethodOutputBindAttribute>
-                        (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
-                                default:
-                                    throw new Exception("Unknown HookType");
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
+                            case HookType.Entry:
+                                CecilHelper.InjectReturnableEntryMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute,
+                                    UseOutputBindAttribute, MethodOutputBindAttribute>
+                                    (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
+                            case HookType.Exit:
+                                CecilHelper.InjectReturnableExitMethod<ParameterBindAttribute, ThisBindAttribute, InputBindAttribute, LocalBindAttribute,
+                                    UseOutputBindAttribute, MethodOutputBindAttribute>
+                    (cecilContext, hookTypeName, hookMethodName, typeName, methodName); break;
+                            default:
+                                throw new Exception("Unknown HookType");
                         }
                     }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
             }
         }
 
@@ -176,64 +162,57 @@ namespace Farmhand
 
         protected override void HookConstructionToMethodRedirectors(CecilContext cecilContext)
         {
-            try
+            var methods = FarmhandAssemblies.SelectMany(a => a.GetTypes())
+                        .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+                        .Where(m => m.GetCustomAttributes(typeof(HookRedirectConstructorToMethodAttribute), false).Any())
+                        .ToArray();
+
+            foreach (var method in methods)
             {
-                var methods = FarmhandAssemblies.SelectMany(a => a.GetTypes())
-                            .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
-                            .Where(m => m.GetCustomAttributes(typeof(HookRedirectConstructorToMethodAttribute), false).Any())
-                            .ToArray();
-
-                foreach (var method in methods)
+                // Check if this method has any properties that would immediately disqualify it from using this hook
+                if (method.ReturnType == typeof(void))
                 {
-                    // Check if this method has any properties that would immediately disqualify it from using this hook
-                    if (method.ReturnType == typeof(void))
-                    {
-                        Logging.Log.Warning($"{method.Name} in {method.DeclaringType.FullName} cannot be used in a hook because it does not return a value!");
-                        continue;
-                    }
-                    if (!method.IsStatic)
-                    {
-                        Logging.Log.Warning($"{method.Name} in {method.DeclaringType.FullName} cannot be used in a hook because it is not static!");
-                        continue;
-                    }
+                    Logging.Log.Warning($"{method.Name} in {method.DeclaringType.FullName} cannot be used in a hook because it does not return a value!");
+                    continue;
+                }
+                if (!method.IsStatic)
+                {
+                    Logging.Log.Warning($"{method.Name} in {method.DeclaringType.FullName} cannot be used in a hook because it is not static!");
+                    continue;
+                }
 
-                    // Get the type that the method returns
-                    var typeName = method.ReturnType.FullName;
-                    // Get the name of the method
-                    var methodName = method.Name;
-                    // Get the type name of the method
-                    var methodDeclaringType = method.DeclaringType.FullName;
-                    // Get an array of parameters that the method returns
-                    var methodParameterInfo = method.GetParameters();
-                    Type[] methodParamters = new Type[methodParameterInfo.Length];
-                    for (int i = 0; i < methodParamters.Length; i++)
+                // Get the type that the method returns
+                var typeName = method.ReturnType.FullName;
+                // Get the name of the method
+                var methodName = method.Name;
+                // Get the type name of the method
+                var methodDeclaringType = method.DeclaringType.FullName;
+                // Get an array of parameters that the method returns
+                var methodParameterInfo = method.GetParameters();
+                Type[] methodParamters = new Type[methodParameterInfo.Length];
+                for (int i = 0; i < methodParamters.Length; i++)
+                {
+                    methodParamters[i] = methodParameterInfo[i].ParameterType;
+                }
+
+                // Get all the hooks for this method
+                var hookAttributes = method.GetCustomAttributes(typeof(HookRedirectConstructorToMethodAttribute), false).Cast<HookRedirectConstructorToMethodAttribute>();
+
+                foreach (var hook in hookAttributes)
+                {
+                    // Get the type name that contains the method we're hooking in
+                    var hookTypeName = hook.Type;
+                    // Get the name of the method we're hooking in
+                    var hookMethodName = hook.Method;
+                    try
                     {
-                        methodParamters[i] = methodParameterInfo[i].ParameterType;
+                        CecilHelper.RedirectConstructorToMethod(cecilContext, method.ReturnType, hookTypeName, hookMethodName, methodDeclaringType, methodName, methodParamters);
                     }
-
-                    // Get all the hooks for this method
-                    var hookAttributes = method.GetCustomAttributes(typeof(HookRedirectConstructorToMethodAttribute), false).Cast<HookRedirectConstructorToMethodAttribute>();
-
-                    foreach (var hook in hookAttributes)
+                    catch (Exception ex)
                     {
-                        // Get the type name that contains the method we're hooking in
-                        var hookTypeName = hook.Type;
-                        // Get the name of the method we're hooking in
-                        var hookMethodName = hook.Method;
-                        try
-                        {
-                            CecilHelper.RedirectConstructorToMethod(cecilContext, method.ReturnType, hookTypeName, hookMethodName, methodDeclaringType, methodName, methodParamters);
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
-                        }
+                        Console.WriteLine($"Failed to Inject {typeName}.{methodName} into {hookTypeName}.{hookMethodName}\n\t{ex.Message}");
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
             }
         }
 


### PR DESCRIPTION
This is a very rough 'fix', so you may want something cleaner.

This will allow any exceptions during the patching process to propagate back up to Main and crash the program. This way, the proper build step will fail if something is patched incorrectly.

So normally when you run it manually you could get something like:
```
Failed to Inject <blah> into <blah>
	Object reference not set to an instance of an object
First Pass Installation Complete
```
But in Visual Studio things would seem to work, until you play the game and get to the proper point and nothing happens (or crash with no error, as seems to be the case when this happens for me).

With this change, Visual Studio will get an error saying: `The command ""\Farmhand\Bin\FarmhandInstaller-Console.exe" -pass1 -disablegrm" exited with code 255.	` 

You can see the output on the Output tab if you set "Tools > Options > Projects and Solutions > Build and Run > MSBuild project build output verbosity" to "Normal" instead of "Minimal". (However, it is a bit cumbersome to find the output since VS keeps building the other projects even when the stage fails. [This](https://marketplace.visualstudio.com/items?itemName=EinarEgilsson.StopOnFirstBuildError) extension will make the build process stop when a stage fails, leaving the output near the bottom.)
