### PR TITLE
Make cancelable injections fail for non-void methods.

### DIFF
--- a/Installers/Patcher/FarmhandPatcherCommon/Helpers/CecilHelper.cs
+++ b/Installers/Patcher/FarmhandPatcherCommon/Helpers/CecilHelper.cs
@@ -84,6 +84,8 @@ namespace Farmhand.Helpers
 
             if (cancelable)
             {
+                if (ilProcessor.Body.Method.MethodReturnType.ReturnType.FullName != stardewContext.GetTypeReference(typeof(void)).FullName)
+                    throw new InvalidOperationException("Cancelable hooks are only supported for methods returning void");
                 var branch = ilProcessor.Create(OpCodes.Brtrue, ilProcessor.Body.Instructions.Last());
                 ilProcessor.InsertAfter(callEnterInstruction, branch);
             }


### PR DESCRIPTION
Otherwise, they just crash the game since there won't be anything on the stack to return. ([ILSpy also fails to decompile the modified method.](http://pastebin.com/BpKH3XTR)) I tried using an exit hook to change the return but it doesn't fix things.

An alternative would be to add a way for a cancelable hook to return a value to be used for when things are canceled. Off-hand, I can't think of a simple and clean way of doing this.

An example of it failing is the OnBeforeSave event I put in a day or two ago.