### PR TITLE
StardewObject ID mismatch fix

### DIFF
--- a/Libraries/FarmhandGame/Item/StardewObject.cs
+++ b/Libraries/FarmhandGame/Item/StardewObject.cs
@@ -7,6 +7,9 @@ using System.Linq;
 using System.Text;
 using Microsoft.Xna.Framework.Graphics;
 using xTile.Dimensions;
+using System.Runtime.Serialization;
+using Farmhand.Logging;
+using Farmhand.Attributes;
 
 namespace Farmhand.Overrides.Game.Item
 {
@@ -37,6 +40,30 @@ namespace Farmhand.Overrides.Game.Item
         public StardewObject(Vector2 tileLocation, int parentSheetIndex, string name, bool canBeSetDown, bool canBeGrabbed, bool isHoedirt, bool isSpawnedObject) :
             base(tileLocation, parentSheetIndex, name, canBeSetDown, canBeGrabbed, isHoedirt, isSpawnedObject)
         {
+        }
+
+        // Fixes the Id associated with this object to be what is described in the various item registries
+        // Idealy, this would be called immediately after deserialization, but xml serialization doesn't provide any functionality for that
+        public void FixId()
+        {
+            var type = this.GetType();
+            int expectedId = -1;
+
+            if(Farmhand.API.Items.Item.RegisteredTypeInformation.ContainsKey(type))
+            {
+                expectedId = Farmhand.API.Items.Item.RegisteredTypeInformation[type].Id;
+            }
+
+            if (Farmhand.API.Items.BigCraftable.RegisteredTypeInformation.ContainsKey(type))
+            {
+                expectedId = Farmhand.API.Items.BigCraftable.RegisteredTypeInformation[type].Id;
+            }
+
+            if (expectedId != -1 && parentSheetIndex != expectedId)
+            {
+                Log.Error($"Correcting id mismatch - {type.Name} - {parentSheetIndex} != {expectedId}");
+                parentSheetIndex = expectedId;
+            }
         }
 
         // Overriden methods
@@ -438,6 +465,7 @@ namespace Farmhand.Overrides.Game.Item
         /// </summary>
         public override void reloadSprite()
         {
+            FixId();
             base.reloadSprite();
         }
 


### PR DESCRIPTION
- Added a fix for StardewObjects to sort out their mismatched IDs when
reloadSprite() is called. A better implementation would be to do this
right after serialization for every object, but xml serialization
doesn't have that kind of functionality. This should help fix a few
things for now while we sort this out.