### PR TITLE
ID Fixing

### DIFF
--- a/Libraries/Farmhand/API/Crops/Crop.cs
+++ b/Libraries/Farmhand/API/Crops/Crop.cs
@@ -1,4 +1,6 @@
 ﻿using Farmhand.API.Utilities;
+using Farmhand.Attributes;
+using Farmhand.Logging;
 using StardewValley;
 using System;
 using System.Collections.Generic;
@@ -8,7 +10,10 @@ namespace Farmhand.API.Crops
 {
     public class Crop
     {
+        private static List<StardewValley.Crop> deserializedCrops = new List<StardewValley.Crop>();
+
         public static Dictionary<int, CropInformation> Crops { get; } = new Dictionary<int, CropInformation>();
+        public static Dictionary<Type, CropInformation> RegisteredTypeInformation { get; } = new Dictionary<Type, CropInformation>();
 
         /// <summary>
         /// Registers a new crop
@@ -25,6 +30,44 @@ namespace Farmhand.API.Crops
 
             Crops.Add(crop.Seed, crop);
             TextureUtility.AddSpriteToSpritesheet(ref Game1.cropSpriteSheet, crop.Texture, crop.Id, 128, 32);
+            RegisteredTypeInformation[typeof(T)] = crop;
+        }
+
+        // Uses the registered deserialized objects list to fix all the IDs
+        internal static void FixupCropIds(object sender, System.EventArgs e)
+        {
+            foreach (StardewValley.Crop deserializedCrop in deserializedCrops)
+            {
+                var type = deserializedCrop.GetType();
+
+                if (RegisteredTypeInformation.ContainsKey(type))
+                {
+                    int expectedIndexOfHarvest = RegisteredTypeInformation[type].Yield;
+                    int expectedRowInSpriteSheet = RegisteredTypeInformation[type].Id;
+
+                    if (deserializedCrop.indexOfHarvest != expectedIndexOfHarvest)
+                    {
+                        Log.Warning($"Correcting harvest index mismatch - {type.Name} - {deserializedCrop.indexOfHarvest} != {expectedIndexOfHarvest}");
+                        deserializedCrop.indexOfHarvest = expectedIndexOfHarvest;
+                    }
+
+                    if (deserializedCrop.rowInSpriteSheet != expectedRowInSpriteSheet)
+                    {
+                        Log.Warning($"Correcting id mismatch - {type.Name} - {deserializedCrop.rowInSpriteSheet} != {expectedRowInSpriteSheet}");
+                        deserializedCrop.rowInSpriteSheet = expectedRowInSpriteSheet;
+                    }
+                }
+            }
+        }
+
+        // Is called from the default constructor of StardewValley.Crop, and alerts this registry to fix its ID after loading is finished
+        [Hook(HookType.Exit, "StardewValley.Crop", "System.Void StardewValley.Crop::.ctor()")]
+        public static void RegisterDeserializingCrop([ThisBind] object @this)
+        {
+            if (@this is StardewValley.Crop)
+            {
+                deserializedCrops.Add(@this as StardewValley.Crop);
+            }
         }
     }
 }

--- a/Libraries/Farmhand/API/Player/Player.cs
+++ b/Libraries/Farmhand/API/Player/Player.cs
@@ -50,6 +50,16 @@ namespace Farmhand.API.Player
             player.addItemToInventory(new T());
         }
 
+        public static void AddObject(StardewValley.Object @object, Farmer player = null)
+        {
+            if (player == null)
+            {
+                player = Game1.player;
+            }
+
+            player.addItemToInventory(@object);
+        }
+
         public static void AddTool<T>(Farmer player = null) where T : StardewValley.Tool, new()
         {
             if (player == null)
@@ -58,6 +68,16 @@ namespace Farmhand.API.Player
             }
 
             player.addItemToInventory(new T());
+        }
+
+        public static void AddTool(StardewValley.Tool tool, Farmer player = null)
+        {
+            if (player == null)
+            {
+                player = Game1.player;
+            }
+
+            player.addItemToInventory(tool);
         }
     }
 }

--- a/Libraries/Farmhand/API/Tools/Weapon.cs
+++ b/Libraries/Farmhand/API/Tools/Weapon.cs
@@ -1,4 +1,6 @@
 ﻿using Farmhand.API.Utilities;
+using Farmhand.Attributes;
+using Farmhand.Logging;
 using StardewValley;
 using System;
 using System.Collections.Generic;
@@ -7,7 +9,10 @@ namespace Farmhand.API.Tools
 {
     public class Weapon
     {
+        private static List<StardewValley.Tools.MeleeWeapon> deserializedWeapons = new List<StardewValley.Tools.MeleeWeapon>();
+
         public static List<WeaponInformation> Weapons { get; } = new List<WeaponInformation>();
+        public static Dictionary<Type, WeaponInformation> RegisteredTypeInformation { get; } = new Dictionary<Type, WeaponInformation>();
 
         /// <summary>
         /// Registers a new weapon
@@ -22,7 +27,41 @@ namespace Farmhand.API.Tools
 
             weapon.Id = IdManager.AssignNewIdSequential(Game1.content.Load<Dictionary<int, string>>("Data\\weapons"));
             Weapons.Add(weapon);
+            RegisteredTypeInformation[typeof(T)] = weapon;
             TextureUtility.AddSpriteToSpritesheet(ref StardewValley.Tool.weaponsTexture, weapon.Texture, weapon.Id, 16, 16);
+        }
+
+        // Uses the registered deserialized objects list to fix all the IDs
+        internal static void FixupWeaponIds(object sender, System.EventArgs e)
+        {
+            foreach (StardewValley.Tools.MeleeWeapon deserializedWeapon in deserializedWeapons)
+            {
+                var type = deserializedWeapon.GetType();
+                int expectedId = -1;
+
+                if (RegisteredTypeInformation.ContainsKey(type))
+                {
+                    expectedId = RegisteredTypeInformation[type].Id;
+
+                    if (deserializedWeapon.currentParentTileIndex != expectedId)
+                    {
+                        Log.Warning($"Correcting id mismatch - {type.Name} - {deserializedWeapon.parentSheetIndex} != {expectedId}");
+                        deserializedWeapon.initialParentTileIndex = expectedId;
+                        deserializedWeapon.currentParentTileIndex = expectedId;
+                        deserializedWeapon.indexOfMenuItemView = expectedId;
+                    }
+                }
+            }
+        }
+
+        // Is called from the default constructor of StardewValley.Tools.MeleeWeapon, and alerts this registry to fix its ID after loading is finished
+        [Hook(HookType.Exit, "StardewValley.Tools.MeleeWeapon", "System.Void StardewValley.Tools.MeleeWeapon::.ctor()")]
+        public static void RegisterDeserializingObject([ThisBind] object @this)
+        {
+            if (@this is StardewValley.Tools.MeleeWeapon)
+            {
+                deserializedWeapons.Add(@this as StardewValley.Tools.MeleeWeapon);
+            }
         }
     }
 }

--- a/Libraries/Farmhand/Events/PlayerEvents.cs
+++ b/Libraries/Farmhand/Events/PlayerEvents.cs
@@ -51,7 +51,6 @@ namespace Farmhand.Events
         
         internal static void InvokeFarmerChanged(Farmer priorFarmer, Farmer newFarmer)
         {
-            Farmhand.API.Items.Item.FixupItemIds(null, null);
             EventCommon.SafeInvoke(OnFarmerChanged, newFarmer, new EventArgsOnFarmerChanged(priorFarmer, newFarmer));
         }
 

--- a/Libraries/Farmhand/Events/Save.cs
+++ b/Libraries/Farmhand/Events/Save.cs
@@ -2,6 +2,9 @@
 using Farmhand.Attributes;
 using Farmhand.Events.Arguments.SaveEvents;
 using System.Collections.Generic;
+using Farmhand.API.Items;
+using Farmhand.API.Crops;
+using Farmhand.API.Tools;
 
 namespace Farmhand.Events
 {
@@ -73,6 +76,12 @@ namespace Farmhand.Events
         // Triggered by PropertyWatcher
         internal static void InvokeOnAfterLoad()
         {
+            // Fix IDs after load, in all our ID based registries
+            Item.FixupItemIds(null, null);
+            BigCraftable.FixupBigCraftableIds(null, null);
+            Crop.FixupCropIds(null, null);
+            Weapon.FixupWeaponIds(null, null);
+
             EventCommon.SafeInvoke(OnAfterLoad, null, new EventArgsOnAfterLoad());
         }
     }

--- a/Libraries/FarmhandGame/Item/BigCraftable.cs
+++ b/Libraries/FarmhandGame/Item/BigCraftable.cs
@@ -15,16 +15,17 @@ namespace Farmhand.Overrides.Game.Item
         // Big Craftable Information
         public BigCraftableInformation Information { get; set; }
 
-        public BigCraftable(BigCraftableInformation information) :
-            base(Vector2.Zero, information.Id, false)
+        // Default constructor for serialization
+        protected BigCraftable() :
+            base()
         {
-            Information = information;
+
         }
 
-        public BigCraftable(BigCraftableInformation information, Vector2 vector, int Id, bool isRecipe = false) :
-            base(vector, Id, isRecipe)
+        public BigCraftable(BigCraftableInformation information, Vector2 vector, bool isRecipe = false) :
+            base(vector, information.Id, isRecipe)
         {
-            Information = information;
+            this.Information = information;
         }
     }
 }

--- a/Libraries/FarmhandGame/Item/StardewObject.cs
+++ b/Libraries/FarmhandGame/Item/StardewObject.cs
@@ -7,6 +7,9 @@ using System.Linq;
 using System.Text;
 using Microsoft.Xna.Framework.Graphics;
 using xTile.Dimensions;
+using System.Runtime.Serialization;
+using Farmhand.Logging;
+using Farmhand.Attributes;
 
 namespace Farmhand.Overrides.Game.Item
 {
@@ -37,6 +40,30 @@ namespace Farmhand.Overrides.Game.Item
         public StardewObject(Vector2 tileLocation, int parentSheetIndex, string name, bool canBeSetDown, bool canBeGrabbed, bool isHoedirt, bool isSpawnedObject) :
             base(tileLocation, parentSheetIndex, name, canBeSetDown, canBeGrabbed, isHoedirt, isSpawnedObject)
         {
+        }
+
+        // Fixes the Id associated with this object to be what is described in the various item registries
+        // Idealy, this would be called immediately after deserialization, but xml serialization doesn't provide any functionality for that
+        public void FixId()
+        {
+            var type = this.GetType();
+            int expectedId = -1;
+
+            if(Farmhand.API.Items.Item.RegisteredTypeInformation.ContainsKey(type))
+            {
+                expectedId = Farmhand.API.Items.Item.RegisteredTypeInformation[type].Id;
+            }
+
+            if (Farmhand.API.Items.BigCraftable.RegisteredTypeInformation.ContainsKey(type))
+            {
+                expectedId = Farmhand.API.Items.BigCraftable.RegisteredTypeInformation[type].Id;
+            }
+
+            if (expectedId != -1 && parentSheetIndex != expectedId)
+            {
+                Log.Error($"Correcting id mismatch - {type.Name} - {parentSheetIndex} != {expectedId}");
+                parentSheetIndex = expectedId;
+            }
         }
 
         // Overriden methods
@@ -438,6 +465,7 @@ namespace Farmhand.Overrides.Game.Item
         /// </summary>
         public override void reloadSprite()
         {
+            FixId();
             base.reloadSprite();
         }
 

--- a/Libraries/FarmhandGame/Item/StardewObject.cs
+++ b/Libraries/FarmhandGame/Item/StardewObject.cs
@@ -42,30 +42,6 @@ namespace Farmhand.Overrides.Game.Item
         {
         }
 
-        // Fixes the Id associated with this object to be what is described in the various item registries
-        // Idealy, this would be called immediately after deserialization, but xml serialization doesn't provide any functionality for that
-        public void FixId()
-        {
-            var type = this.GetType();
-            int expectedId = -1;
-
-            if(Farmhand.API.Items.Item.RegisteredTypeInformation.ContainsKey(type))
-            {
-                expectedId = Farmhand.API.Items.Item.RegisteredTypeInformation[type].Id;
-            }
-
-            if (Farmhand.API.Items.BigCraftable.RegisteredTypeInformation.ContainsKey(type))
-            {
-                expectedId = Farmhand.API.Items.BigCraftable.RegisteredTypeInformation[type].Id;
-            }
-
-            if (expectedId != -1 && parentSheetIndex != expectedId)
-            {
-                Log.Error($"Correcting id mismatch - {type.Name} - {parentSheetIndex} != {expectedId}");
-                parentSheetIndex = expectedId;
-            }
-        }
-
         // Overriden methods
 
         /// <summary>
@@ -465,7 +441,6 @@ namespace Farmhand.Overrides.Game.Item
         /// </summary>
         public override void reloadSprite()
         {
-            FixId();
             base.reloadSprite();
         }
 

--- a/Mods/RecipeTestMod/Items/Heart.cs
+++ b/Mods/RecipeTestMod/Items/Heart.cs
@@ -17,8 +17,16 @@ namespace RecipeTestMod.Items
             Type = ItemType.Basic
         });
 
-        public Heart()
-            : base(Vector2.Zero, Information.Id, Information.Name, true, true, false, false)
+        // A default constructor that calls the base default constructor is required for proper ID fixing.
+        // Using the default constructor to create an object intended to be used is not recommended
+        protected Heart()
+            : base()
+        {
+            Farmhand.Logging.Log.Success("Deserializing Heart Class");
+        }
+
+        public Heart(ItemInformation information)
+            : base(Vector2.Zero, information.Id, information.Name, true, true, false, false)
         {
             Farmhand.Logging.Log.Success("Using Heart Class");
         }

--- a/Mods/RecipeTestMod/Items/PuppyTail.cs
+++ b/Mods/RecipeTestMod/Items/PuppyTail.cs
@@ -17,8 +17,16 @@ namespace RecipeTestMod.Items
             Type = ItemType.Basic
         });
 
-        public PuppyTail()
-            : base(Vector2.Zero, Information.Id, Information.Name, true, true, false, false)
+        // A default constructor that calls the base default constructor is required for proper ID fixing.
+        // Using the default constructor to create an object intended to be used is not recommended
+        protected PuppyTail()
+            : base()
+        {
+            Farmhand.Logging.Log.Success("Deserializing PuppyTail Class");
+        }
+
+        public PuppyTail(ItemInformation information)
+            : base(Vector2.Zero, information.Id, information.Name, true, true, false, false)
         {
             Farmhand.Logging.Log.Success("Using PuppyTail Class");
         }

--- a/Mods/RecipeTestMod/Items/RabbitsPaw.cs
+++ b/Mods/RecipeTestMod/Items/RabbitsPaw.cs
@@ -17,8 +17,16 @@ namespace RecipeTestMod.Items
             Type = ItemType.Basic
         });
 
-        public RabbitsPaw()
-            : base(Vector2.Zero, Information.Id, Information.Name, true, true, false, false)
+        // A default constructor that calls the base default constructor is required for proper ID fixing.
+        // Using the default constructor to create an object intended to be used is not recommended
+        protected RabbitsPaw()
+            : base()
+        {
+            Farmhand.Logging.Log.Success("Deserializing RabbitsPaw Class");
+        }
+
+        public RabbitsPaw(ItemInformation information)
+            : base(Vector2.Zero, information.Id, information.Name, true, true, false, false)
         {
             Farmhand.Logging.Log.Success("Using RabbitsPaw Class");
         }

--- a/Mods/RecipeTestMod/RecipeTestMod.cs
+++ b/Mods/RecipeTestMod/RecipeTestMod.cs
@@ -35,9 +35,9 @@ namespace RecipeTestMod
         private void PlayerEvents_OnFarmerChanged(object sender, EventArgsOnFarmerChanged e)
         {
             Farmhand.API.Player.Player.AddRecipe(VoidStar.Recipe.PrivateName);
-            Farmhand.API.Player.Player.AddObject<Heart>();
-            Farmhand.API.Player.Player.AddObject<PuppyTail>();
-            Farmhand.API.Player.Player.AddObject<RabbitsPaw>();
+            Farmhand.API.Player.Player.AddObject(new Heart(Heart.Information));
+            Farmhand.API.Player.Player.AddObject(new PuppyTail(PuppyTail.Information));
+            Farmhand.API.Player.Player.AddObject(new RabbitsPaw(RabbitsPaw.Information));
         }
 
     }

--- a/Mods/TestBigCraftableMod/BigCraftables/TestBigCraftable.cs
+++ b/Mods/TestBigCraftableMod/BigCraftables/TestBigCraftable.cs
@@ -22,16 +22,18 @@ namespace TestBigCraftableMod.BigCraftables
             IsLamp = false
         });
 
-        public TestBigCraftable() :
-            base(StaticInformation)
+        // A default constructor that calls the base default constructor is required for proper ID fixing.
+        // Using the default constructor to create an object intended to be used is not recommended
+        protected TestBigCraftable() :
+            base()
         {
 
         }
 
-        public TestBigCraftable(BigCraftableInformation information, Vector2 vector, int Id, bool isRecipe = false) :
-            base(information, vector, Id, isRecipe)
+        public TestBigCraftable(BigCraftableInformation information, Vector2 vector, bool isRecipe = false) :
+            base(information, vector, isRecipe)
         {
-            Information = information;
+            
         }
 
         public override bool clicked(Farmer who)

--- a/Mods/TestBigCraftableMod/TestBigCraftableMod.cs
+++ b/Mods/TestBigCraftableMod/TestBigCraftableMod.cs
@@ -1,5 +1,6 @@
 ﻿using Farmhand;
 using Farmhand.API.Items;
+using Microsoft.Xna.Framework;
 using TestBigCraftableMod.BigCraftables;
 
 namespace TestBigCraftableMod
@@ -26,7 +27,7 @@ namespace TestBigCraftableMod
 
         private void PlayerEvents_OnFarmerChanged(object sender, System.EventArgs e)
         {
-            Farmhand.API.Player.Player.AddObject<TestBigCraftable>();
+            Farmhand.API.Player.Player.AddObject(new TestBigCraftable(TestBigCraftable.StaticInformation, Vector2.Zero));
         }
     }
 }

--- a/Mods/TestCropMod/Items/Bluemelon.cs
+++ b/Mods/TestCropMod/Items/Bluemelon.cs
@@ -18,8 +18,16 @@ namespace TestCropMod.Items
             Edibility = 15
         });
 
-        public Bluemelon()
-            : base(Vector2.Zero, Information.Id, Information.Name, true, true, false, false)
+        // A default constructor that calls the base default constructor is required for proper ID fixing.
+        // Using the default constructor to create an object intended to be used is not recommended
+        protected Bluemelon()
+            : base()
+        {
+
+        }
+
+        public Bluemelon(ItemInformation information)
+            : base(Vector2.Zero, information.Id, information.Name, true, true, false, false)
         {
             
         }

--- a/Mods/TestCropMod/Items/BluemelonSeeds.cs
+++ b/Mods/TestCropMod/Items/BluemelonSeeds.cs
@@ -17,8 +17,16 @@ namespace TestCropMod.Items
             Type = ItemType.Basic
         });
 
-        public BluemelonSeeds()
-            : base(Vector2.Zero, Information.Id, Information.Name, true, true, false, false)
+        // A default constructor that calls the base default constructor is required for proper ID fixing.
+        // Using the default constructor to create an object intended to be used is not recommended
+        protected BluemelonSeeds()
+            : base()
+        {
+
+        }
+
+        public BluemelonSeeds(ItemInformation information)
+            : base(Vector2.Zero, information.Id, information.Name, true, true, false, false)
         {
 
         }

--- a/Mods/TestToolMod/TestToolMod.cs
+++ b/Mods/TestToolMod/TestToolMod.cs
@@ -23,10 +23,10 @@ namespace TestToolMod
         private void GameEvents_OnAfterLoadedContent(object sender, System.EventArgs e)
         {
             // Register the tool so it can be added to the sprite sheet
-            Farmhand.API.Tools.Tool.RegisterTool<StardewValley.Tool>(TestTool.Information);
+            Farmhand.API.Tools.Tool.RegisterTool<TestTool>(TestTool.Information);
 
             // Register the weapon
-            Farmhand.API.Tools.Weapon.RegisterWeapon<StardewValley.Tools.MeleeWeapon>(TestWeapon.Information);
+            Farmhand.API.Tools.Weapon.RegisterWeapon<TestWeapon>(TestWeapon.Information);
         }
 
         private void PlayerEvents_OnFarmerChanged(object sender, System.EventArgs e)
@@ -61,7 +61,7 @@ namespace TestToolMod
             // Give the player the tool
             if (!hasWeapon)
             {
-                Farmhand.API.Player.Player.AddTool<TestWeapon>();
+                Farmhand.API.Player.Player.AddTool(new TestWeapon(TestWeapon.Information));
             }
         }
     }

--- a/Mods/TestToolMod/Weapons/TestWeapon.cs
+++ b/Mods/TestToolMod/Weapons/TestWeapon.cs
@@ -22,9 +22,17 @@ namespace TestToolMod.Weapons
             CritMultiplier = 3
         });
 
-        public TestWeapon() : base(Information.Id)
+        // A default constructor that calls the base default constructor is required for proper ID fixing.
+        // Using the default constructor to create an object intended to be used is not recommended
+        protected TestWeapon() : base()
         {
             
+        }
+
+        public TestWeapon(WeaponInformation information)
+            : base(information.Id)
+        {
+
         }
     }
 }


### PR DESCRIPTION
- Added functionality to fix ID conflicts after deserialization through
registering objects created with the default constructor with the proper
registry, then fixing all registered objects when deserialization is
complete.

- Changed and fix example mods and override classes to prevent use of
the default constructor for anything but being the default constructor.
Calling any base but the default base(base()) causes the object to not
be added to the registry, and not have its ID fixed.

- Objects only have their ID fixed if they are not the default type(such
as a StardewValley.Object). The ID checking relies on the object being a
child type of the default, so that the type is uniquely tied to the ID.
This means that if an item is created internally by StardewValley, and
it creates it as a StardewValley.Object, rather than an
ExampleMod.ExampleItem : StardewValley.Object, the ID fixer will have no
way of knowing what ID to fix it to. This can be fixed by the use of
factories, such as the one used already by
Farmhand.API.Items.BigCraftable.Create, which finds every instance of
instantiation of big craftable objects, and assures that if there is a
custom type registered by that ID, it is built using the type
registered. This should be done for everything using sequential IDs, to
assure that they are built as the correct type.